### PR TITLE
LEL-014 (feat): add `JournalOption` interface

### DIFF
--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/ClimateOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/ClimateOption.kt
@@ -1,10 +1,8 @@
 package io.github.faening.lello.core.model.journal
 
-import java.io.Serializable
-
 data class ClimateOption(
-    val id: Int?,
-    val description: String,
-    val blocked: Boolean = false,
-    val active: Boolean = true
-) : Serializable
+    override val id: Int?,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true
+) : JournalOption

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/EmotionOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/EmotionOption.kt
@@ -1,10 +1,8 @@
 package io.github.faening.lello.core.model.journal
 
-import java.io.Serializable
-
 data class EmotionOption(
-    val id: Int?,
-    val description: String,
-    val blocked: Boolean = false,
-    val active: Boolean = true
-) : Serializable
+    override val id: Int?,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true
+) : JournalOption

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/HealthOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/HealthOption.kt
@@ -1,10 +1,8 @@
 package io.github.faening.lello.core.model.journal
 
-import java.io.Serializable
-
 data class HealthOption(
-    val id: Int?,
-    val description: String,
-    val blocked: Boolean = false,
-    val active: Boolean = true
-) : Serializable
+    override val id: Int?,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true
+) : JournalOption

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/JournalOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/JournalOption.kt
@@ -1,0 +1,10 @@
+package io.github.faening.lello.core.model.journal
+
+import java.io.Serializable
+
+interface JournalOption : Serializable {
+    val id: Int?
+    val description: String
+    val blocked: Boolean
+    val active: Boolean
+}

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/LocationOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/LocationOption.kt
@@ -1,10 +1,8 @@
 package io.github.faening.lello.core.model.journal
 
-import java.io.Serializable
-
 data class LocationOption (
-    val id: Int?,
-    val description: String,
-    val blocked: Boolean = false,
-    val active: Boolean = true
-) : Serializable
+    override val id: Int?,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true
+) : JournalOption

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/SocialOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/SocialOption.kt
@@ -1,10 +1,8 @@
 package io.github.faening.lello.core.model.journal
 
-import java.io.Serializable
-
 data class SocialOption (
-    val id: Int?,
-    val description: String,
-    val blocked: Boolean = false,
-    val active: Boolean = true
-) : Serializable
+    override val id: Int?,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true
+) : JournalOption


### PR DESCRIPTION
## Summary
- introduce `JournalOption` interface
- make climate, emotion, health, location and social option models implement `JournalOption`

## Testing
- `./gradlew test --no-daemon` *(fails: Calculating task graph as no cached configuration is available for tasks: test)*

------
https://chatgpt.com/codex/tasks/task_e_6845b253f494832c94b4538c7ae248f6