### PR TITLE
LEL-014 feat(feature/mood): add `ClimateOptionSettingsScreen`

### DIFF
--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
@@ -11,6 +11,8 @@ import androidx.navigation.compose.navigation
 import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
 import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSettingsEmotionRegisterScreen
 import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSettingsEmotionScreen
+import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateScreen
 
 object JournalSettingsDestinations {
     const val GRAPH = "journal_settings_graph"
@@ -49,6 +51,29 @@ fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
         composable(JournalSettingsDestinations.EMOTION_REGISTER) { backStackEntry ->
             val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
             JournalSettingsEmotionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.CLIMATE_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsClimateScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.CLIMATE_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.CLIMATE_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsClimateRegisterScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
             )

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -3,7 +3,9 @@ package io.github.faening.lello.feature.journal.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.faening.lello.core.domain.usecase.options.ClimateOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.EmotionOptionUseCase
+import io.github.faening.lello.core.model.journal.ClimateOption
 import io.github.faening.lello.core.model.journal.EmotionOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,20 +14,33 @@ import javax.inject.Inject
 
 @HiltViewModel
 class JournalSettingsViewModel @Inject constructor(
-    emotionOptionUseCase: EmotionOptionUseCase
+    emotionOptionUseCase: EmotionOptionUseCase,
+    climateOptionUseCase: ClimateOptionUseCase
 ) : ViewModel() {
 
     private val _emotionOptions = MutableStateFlow<List<EmotionOption>>(emptyList())
     val emotionOptions: StateFlow<List<EmotionOption>> = _emotionOptions
 
+    private val _climateOptions = MutableStateFlow<List<ClimateOption>>(emptyList())
+    val climateOptions: StateFlow<List<ClimateOption>> = _climateOptions
+
     init {
         viewModelScope.launch {
             emotionOptionUseCase.getAll().collect { _emotionOptions.value = it }
+        }
+        viewModelScope.launch {
+            climateOptionUseCase.getAll().collect { _climateOptions.value = it }
         }
     }
 
     fun toggleEmotionOption(option: EmotionOption, active: Boolean) {
         _emotionOptions.value = _emotionOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleClimateOption(option: ClimateOption, active: Boolean) {
+        _climateOptions.value = _climateOptions.value.map {
             if (it.id == option.id) it.copy(active = active) else it
         }
     }

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/climate/JournalSettingsClimateRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/climate/JournalSettingsClimateRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.climate
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsClimateRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/climate/JournalSettingsClimateScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/climate/JournalSettingsClimateScreen.kt
@@ -1,0 +1,142 @@
+package io.github.faening.lello.feature.journal.settings.screen.climate
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.ClimateOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsClimateScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val climates by viewModel.climateOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsClimateContainer(
+            climates = climates,
+            onToggle = { option, active -> viewModel.toggleClimateOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsClimateContainer(
+    climates: List<ClimateOption>,
+    onToggle: (ClimateOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsClimateTopBar(onBack) },
+        bottomBar = { JournalSettingsClimateBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsClimateContent(
+            climates = climates,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsClimateTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_climate_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsClimateBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_climate_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsClimateContent(
+    climates: List<ClimateOption>,
+    onToggle: (ClimateOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = climates,
+            onToggle = { option, active ->
+                onToggle(option as ClimateOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsClimateScreenPreview() {
+    val climates = listOf(
+        ClimateOption(id = 1, description = "Ensolarado", blocked = false, active = true),
+        ClimateOption(id = 2, description = "Chuvoso", blocked = false, active = false),
+        ClimateOption(id = 3, description = "Frio", blocked = false, active = true)
+    )
+    LelloTheme {
+        JournalSettingsClimateContainer(
+            climates = climates,
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/res/values/strings.xml
+++ b/feature/journal/settings/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="journal_settings_emotion_appbar_title">Emoções</string>
     <string name="journal_settings_emotion_register_button_label">Cadastrar emoção</string>
 
+    <!-- Climate -->
+    <string name="journal_settings_climate_appbar_title">Climas</string>
+    <string name="journal_settings_climate_register_button_label">Cadastrar clima</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- replicate emotion settings UI for climate options
- load climate options in `JournalSettingsViewModel`
- wire new climate screens into `JournalSettingsNavigation`
- add Portuguese strings for climate settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b2f36f94832c80e5d455c6d7c02a