### PR TITLE
LEL-014 feat(feature/mood): add `LocationOptionSettingsScreen`

### DIFF
--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
@@ -13,6 +13,8 @@ import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSe
 import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSettingsEmotionScreen
 import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateRegisterScreen
 import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateScreen
+import io.github.faening.lello.feature.journal.settings.screen.location.JournalSettingsLocationRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.location.JournalSettingsLocationScreen
 
 object JournalSettingsDestinations {
     const val GRAPH = "journal_settings_graph"
@@ -74,6 +76,29 @@ fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
         composable(JournalSettingsDestinations.CLIMATE_REGISTER) { backStackEntry ->
             val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
             JournalSettingsClimateRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.LOCATION_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsLocationScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.LOCATION_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.LOCATION_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsLocationRegisterScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
             )

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.faening.lello.core.domain.usecase.options.ClimateOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.EmotionOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
 import io.github.faening.lello.core.model.journal.ClimateOption
 import io.github.faening.lello.core.model.journal.EmotionOption
+import io.github.faening.lello.core.model.journal.LocationOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class JournalSettingsViewModel @Inject constructor(
     emotionOptionUseCase: EmotionOptionUseCase,
-    climateOptionUseCase: ClimateOptionUseCase
+    climateOptionUseCase: ClimateOptionUseCase,
+    locationOptionUseCase: LocationOptionUseCase,
 ) : ViewModel() {
 
     private val _emotionOptions = MutableStateFlow<List<EmotionOption>>(emptyList())
@@ -24,12 +27,18 @@ class JournalSettingsViewModel @Inject constructor(
     private val _climateOptions = MutableStateFlow<List<ClimateOption>>(emptyList())
     val climateOptions: StateFlow<List<ClimateOption>> = _climateOptions
 
+    private val _locationOptions = MutableStateFlow<List<LocationOption>>(emptyList())
+    val locationOptions: StateFlow<List<LocationOption>> = _locationOptions
+
     init {
         viewModelScope.launch {
             emotionOptionUseCase.getAll().collect { _emotionOptions.value = it }
         }
         viewModelScope.launch {
             climateOptionUseCase.getAll().collect { _climateOptions.value = it }
+        }
+        viewModelScope.launch {
+            locationOptionUseCase.getAll().collect { _locationOptions.value = it }
         }
     }
 
@@ -41,6 +50,12 @@ class JournalSettingsViewModel @Inject constructor(
 
     fun toggleClimateOption(option: ClimateOption, active: Boolean) {
         _climateOptions.value = _climateOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleLocationOption(option: LocationOption, active: Boolean) {
+        _locationOptions.value = _locationOptions.value.map {
             if (it.id == option.id) it.copy(active = active) else it
         }
     }

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/location/JournalSettingsLocationRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/location/JournalSettingsLocationRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.location
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsLocationRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/location/JournalSettingsLocationScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/location/JournalSettingsLocationScreen.kt
@@ -1,0 +1,142 @@
+package io.github.faening.lello.feature.journal.settings.screen.location
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.LocationOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsLocationScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val locations by viewModel.locationOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsLocationContainer(
+            locations = locations,
+            onToggle = { option, active -> viewModel.toggleLocationOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsLocationContainer(
+    locations: List<LocationOption>,
+    onToggle: (LocationOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsLocationTopBar(onBack) },
+        bottomBar = { JournalSettingsLocationBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsLocationContent(
+            locations = locations,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsLocationTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_location_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsLocationBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_location_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsLocationContent(
+    locations: List<LocationOption>,
+    onToggle: (LocationOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = locations,
+            onToggle = { option, active ->
+                onToggle(option as LocationOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsLocationScreenPreview() {
+    val locations = listOf(
+        LocationOption(id = 1, description = "Casa", blocked = false, active = true),
+        LocationOption(id = 2, description = "Trabalho", blocked = false, active = false),
+        LocationOption(id = 3, description = "Parque", blocked = false, active = true)
+    )
+    LelloTheme {
+        JournalSettingsLocationContainer(
+            locations = locations,
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/res/values/strings.xml
+++ b/feature/journal/settings/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="journal_settings_climate_appbar_title">Climas</string>
     <string name="journal_settings_climate_register_button_label">Cadastrar clima</string>
 
+    <!-- Location -->
+    <string name="journal_settings_location_appbar_title">Localizações</string>
+    <string name="journal_settings_location_register_button_label">Cadastrar localização</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- extend `JournalSettingsViewModel` with LocationOption handling
- create `JournalSettingsLocationScreen` and register screen
- wire location screens into `JournalSettingsNavigation`
- add location strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b613a928832caffeefb7346746e8