### PR TITLE
LEL-014 feat(feature/mood): add `SocialOptionSettingsScreen`

### DIFF
--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
@@ -13,6 +13,8 @@ import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSe
 import io.github.faening.lello.feature.journal.settings.screen.emotion.JournalSettingsEmotionScreen
 import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateRegisterScreen
 import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateScreen
+import io.github.faening.lello.feature.journal.settings.screen.social.JournalSettingsSocialRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.social.JournalSettingsSocialScreen
 
 object JournalSettingsDestinations {
     const val GRAPH = "journal_settings_graph"
@@ -74,6 +76,29 @@ fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
         composable(JournalSettingsDestinations.CLIMATE_REGISTER) { backStackEntry ->
             val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
             JournalSettingsClimateRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.SOCIAL_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSocialScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.SOCIAl_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.SOCIAl_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSocialRegisterScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
             )

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.faening.lello.core.domain.usecase.options.ClimateOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.EmotionOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SocialOptionUseCase
 import io.github.faening.lello.core.model.journal.ClimateOption
 import io.github.faening.lello.core.model.journal.EmotionOption
+import io.github.faening.lello.core.model.journal.SocialOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class JournalSettingsViewModel @Inject constructor(
     emotionOptionUseCase: EmotionOptionUseCase,
-    climateOptionUseCase: ClimateOptionUseCase
+    climateOptionUseCase: ClimateOptionUseCase,
+    socialOptionUseCase: SocialOptionUseCase
 ) : ViewModel() {
 
     private val _emotionOptions = MutableStateFlow<List<EmotionOption>>(emptyList())
@@ -24,12 +27,18 @@ class JournalSettingsViewModel @Inject constructor(
     private val _climateOptions = MutableStateFlow<List<ClimateOption>>(emptyList())
     val climateOptions: StateFlow<List<ClimateOption>> = _climateOptions
 
+    private val _socialOptions = MutableStateFlow<List<SocialOption>>(emptyList())
+    val socialOptions: StateFlow<List<SocialOption>> = _socialOptions
+
     init {
         viewModelScope.launch {
             emotionOptionUseCase.getAll().collect { _emotionOptions.value = it }
         }
         viewModelScope.launch {
             climateOptionUseCase.getAll().collect { _climateOptions.value = it }
+        }
+        viewModelScope.launch {
+            socialOptionUseCase.getAll().collect { _socialOptions.value = it }
         }
     }
 
@@ -41,6 +50,12 @@ class JournalSettingsViewModel @Inject constructor(
 
     fun toggleClimateOption(option: ClimateOption, active: Boolean) {
         _climateOptions.value = _climateOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleSocialOption(option: SocialOption, active: Boolean) {
+        _socialOptions.value = _socialOptions.value.map {
             if (it.id == option.id) it.copy(active = active) else it
         }
     }

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.social
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsSocialRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialScreen.kt
@@ -1,0 +1,143 @@
+package io.github.faening.lello.feature.journal.settings.screen.social
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.SocialOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsSocialScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val socialOptions by viewModel.socialOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsSocialContainer(
+            socialOptions = socialOptions,
+            onToggle = { option, active -> viewModel.toggleSocialOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialContainer(
+    socialOptions: List<SocialOption>,
+    onToggle: (SocialOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsSocialTopBar(onBack) },
+        bottomBar = { JournalSettingsSocialBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsSocialContent(
+            socialOptions = socialOptions,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_social_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsSocialBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_social_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialContent(
+    socialOptions: List<SocialOption>,
+    onToggle: (SocialOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = socialOptions,
+            onToggle = { option, active ->
+                onToggle(option as SocialOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsSocialScreenPreview() {
+    val options = listOf(
+        SocialOption(id = 1, description = "Amigos", blocked = false, active = true),
+        SocialOption(id = 2, description = "Família", blocked = false, active = false),
+        SocialOption(id = 3, description = "Colegas", blocked = false, active = true)
+    )
+    LelloTheme {
+        JournalSettingsSocialContainer(
+            socialOptions = options,
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}
+

--- a/feature/journal/settings/src/main/res/values/strings.xml
+++ b/feature/journal/settings/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="journal_settings_climate_appbar_title">Climas</string>
     <string name="journal_settings_climate_register_button_label">Cadastrar clima</string>
 
+    <!-- Social -->
+    <string name="journal_settings_social_appbar_title">Com quem</string>
+    <string name="journal_settings_social_register_button_label">Cadastrar companhia</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- add SocialOption state and toggles in `JournalSettingsViewModel`
- show `JournalSettingsSocialScreen` and register screen via navigation
- implement social settings UI
- add strings for social settings

## Testing
- `./gradlew test` *(fails: Gradle build did not finish in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6848b8599fcc832c94f05c2d1f058cd4