### PR TITLE
LEL-014 feat(feature/mood): add `HealthOptionSettingsScreen`

### DIFF
--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
@@ -15,6 +15,10 @@ import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSe
 import io.github.faening.lello.feature.journal.settings.screen.climate.JournalSettingsClimateScreen
 import io.github.faening.lello.feature.journal.settings.screen.location.JournalSettingsLocationRegisterScreen
 import io.github.faening.lello.feature.journal.settings.screen.location.JournalSettingsLocationScreen
+import io.github.faening.lello.feature.journal.settings.screen.social.JournalSettingsSocialRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.social.JournalSettingsSocialScreen
+import io.github.faening.lello.feature.journal.settings.screen.health.JournalSettingsHealthRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.health.JournalSettingsHealthScreen
 
 object JournalSettingsDestinations {
     const val GRAPH = "journal_settings_graph"
@@ -99,6 +103,52 @@ fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
         composable(JournalSettingsDestinations.LOCATION_REGISTER) { backStackEntry ->
             val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
             JournalSettingsLocationRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.SOCIAL_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSocialScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.SOCIAl_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.SOCIAl_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSocialRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.HEALTH_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsHealthScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.HEALTH_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.HEALTH_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsHealthRegisterScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
             )

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -6,9 +6,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.faening.lello.core.domain.usecase.options.ClimateOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.EmotionOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SocialOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.HealthOptionUseCase
 import io.github.faening.lello.core.model.journal.ClimateOption
 import io.github.faening.lello.core.model.journal.EmotionOption
 import io.github.faening.lello.core.model.journal.LocationOption
+import io.github.faening.lello.core.model.journal.SocialOption
+import io.github.faening.lello.core.model.journal.HealthOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -19,6 +23,8 @@ class JournalSettingsViewModel @Inject constructor(
     emotionOptionUseCase: EmotionOptionUseCase,
     climateOptionUseCase: ClimateOptionUseCase,
     locationOptionUseCase: LocationOptionUseCase,
+    socialOptionUseCase: SocialOptionUseCase,
+    healthOptionUseCase: HealthOptionUseCase,
 ) : ViewModel() {
 
     private val _emotionOptions = MutableStateFlow<List<EmotionOption>>(emptyList())
@@ -30,6 +36,12 @@ class JournalSettingsViewModel @Inject constructor(
     private val _locationOptions = MutableStateFlow<List<LocationOption>>(emptyList())
     val locationOptions: StateFlow<List<LocationOption>> = _locationOptions
 
+    private val _socialOptions = MutableStateFlow<List<SocialOption>>(emptyList())
+    val socialOptions: StateFlow<List<SocialOption>> = _socialOptions
+
+    private val _healthOptions = MutableStateFlow<List<HealthOption>>(emptyList())
+    val healthOptions: StateFlow<List<HealthOption>> = _healthOptions
+
     init {
         viewModelScope.launch {
             emotionOptionUseCase.getAll().collect { _emotionOptions.value = it }
@@ -39,6 +51,12 @@ class JournalSettingsViewModel @Inject constructor(
         }
         viewModelScope.launch {
             locationOptionUseCase.getAll().collect { _locationOptions.value = it }
+        }
+        viewModelScope.launch {
+            socialOptionUseCase.getAll().collect { _socialOptions.value = it }
+        }
+        viewModelScope.launch {
+            healthOptionUseCase.getAll().collect { _healthOptions.value = it }
         }
     }
 
@@ -56,6 +74,18 @@ class JournalSettingsViewModel @Inject constructor(
 
     fun toggleLocationOption(option: LocationOption, active: Boolean) {
         _locationOptions.value = _locationOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleSocialOption(option: SocialOption, active: Boolean) {
+        _socialOptions.value = _socialOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleHealthOption(option: HealthOption, active: Boolean) {
+        _healthOptions.value = _healthOptions.value.map {
             if (it.id == option.id) it.copy(active = active) else it
         }
     }

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/health/JournalSettingsHealthRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/health/JournalSettingsHealthRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.health
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsHealthRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/health/JournalSettingsHealthScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/health/JournalSettingsHealthScreen.kt
@@ -1,0 +1,142 @@
+package io.github.faening.lello.feature.journal.settings.screen.health
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.HealthOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsHealthScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val healthOptions by viewModel.healthOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsHealthContainer(
+            healthOptions = healthOptions,
+            onToggle = { option, active -> viewModel.toggleHealthOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsHealthContainer(
+    healthOptions: List<HealthOption>,
+    onToggle: (HealthOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsHealthTopBar(onBack) },
+        bottomBar = { JournalSettingsHealthBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsHealthContent(
+            healthOptions = healthOptions,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsHealthTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_health_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsHealthBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_health_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsHealthContent(
+    healthOptions: List<HealthOption>,
+    onToggle: (HealthOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = healthOptions,
+            onToggle = { option, active ->
+                onToggle(option as HealthOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsHealthScreenPreview() {
+    val healthOptions = listOf(
+        HealthOption(id = 1, description = "Dor", blocked = false, active = true),
+        HealthOption(id = 2, description = "Gripado", blocked = false, active = false),
+        HealthOption(id = 3, description = "Cansado", blocked = false, active = true)
+    )
+    LelloTheme {
+        JournalSettingsHealthContainer(
+            healthOptions = healthOptions,
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.social
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsSocialRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/social/JournalSettingsSocialScreen.kt
@@ -1,0 +1,142 @@
+package io.github.faening.lello.feature.journal.settings.screen.social
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.SocialOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsSocialScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val socials by viewModel.socialOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsSocialContainer(
+            socials = socials,
+            onToggle = { option, active -> viewModel.toggleSocialOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialContainer(
+    socials: List<SocialOption>,
+    onToggle: (SocialOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsSocialTopBar(onBack) },
+        bottomBar = { JournalSettingsSocialBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsSocialContent(
+            socials = socials,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_social_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsSocialBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_social_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSocialContent(
+    socials: List<SocialOption>,
+    onToggle: (SocialOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = socials,
+            onToggle = { option, active ->
+                onToggle(option as SocialOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsSocialScreenPreview() {
+    val socials = listOf(
+        SocialOption(id = 1, description = "Amigo", blocked = false, active = true),
+        SocialOption(id = 2, description = "Família", blocked = false, active = false),
+        SocialOption(id = 3, description = "Colega", blocked = false, active = true)
+    )
+    LelloTheme {
+        JournalSettingsSocialContainer(
+            socials = socials,
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/res/values/strings.xml
+++ b/feature/journal/settings/src/main/res/values/strings.xml
@@ -14,4 +14,12 @@
     <string name="journal_settings_location_appbar_title">Localizações</string>
     <string name="journal_settings_location_register_button_label">Cadastrar localização</string>
 
+    <!-- Social -->
+    <string name="journal_settings_social_appbar_title">Interações Sociais</string>
+    <string name="journal_settings_social_register_button_label">Cadastrar interação social</string>
+
+    <!-- Health -->
+    <string name="journal_settings_health_appbar_title">Saúde</string>
+    <string name="journal_settings_health_register_button_label">Cadastrar item de saúde</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- add screens for selecting social and health options
- extend JournalSettingsViewModel with SocialOption and HealthOption
- add routes for new screens in JournalSettingsNavigation
- provide string resources for new screens

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_6848ba694508832cb8338ffac54a858d