### PR TITLE
LEL-014 feat(core/database): add `AppetiteOption` into database layer

### DIFF
--- a/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
@@ -2,15 +2,16 @@ package io.github.faening.lello.core.database
 
 import android.util.Log
 import androidx.sqlite.db.SupportSQLiteDatabase
+import io.github.faening.lello.core.database.seed.AppetiteOptionSeed
 import io.github.faening.lello.core.database.seed.ClimateOptionSeed
 import io.github.faening.lello.core.database.seed.EmotionOptionSeed
 import io.github.faening.lello.core.database.seed.HealthOptionSeed
 import io.github.faening.lello.core.database.seed.JournalCategorySeed
 import io.github.faening.lello.core.database.seed.LocationOptionSeed
 import io.github.faening.lello.core.database.seed.SensationOptionSeed
+import io.github.faening.lello.core.database.seed.SleepActivityOptionSeed
 import io.github.faening.lello.core.database.seed.SleepQualityOptionSeed
 import io.github.faening.lello.core.database.seed.SocialOptionSeed
-import io.github.faening.lello.core.database.seed.SleepActivityOptionSeed
 
 /**
  * Classe responsável por centralizar a população de dados iniciais no banco de dados.
@@ -28,6 +29,7 @@ internal object DatabaseSeeder {
         Log.d(TAG, "Iniciando processo de seed do banco de dados")
 
         seedJournalCategory(db)
+        seedAppetiteOptions(db)
         seedClimateOptions(db)
         seedEmotionOptions(db)
         seedHealthOptions(db)
@@ -40,10 +42,10 @@ internal object DatabaseSeeder {
         Log.d(TAG, "Processo de seed do banco de dados concluído com sucesso")
     }
 
-    fun seedJournalCategory(db: SupportSQLiteDatabase) {
-        for (item in JournalCategorySeed.data) {
-            db.execSQL(
-                sql = """
+fun seedJournalCategory(db: SupportSQLiteDatabase) {
+    for (item in JournalCategorySeed.data) {
+        db.execSQL(
+            sql = """
                         INSERT INTO journal_categories (name, short_description, long_description, blocked, active)
                         VALUES (?, ?, ?, ?, ?)
                     """.trimIndent(),
@@ -51,6 +53,22 @@ internal object DatabaseSeeder {
                     item.name,
                     item.shortDescription,
                     item.longDescription,
+                    if (item.blocked) 1 else 0,
+                    if (item.active) 1 else 0
+                )
+        )
+    }
+}
+
+    fun seedAppetiteOptions(db: SupportSQLiteDatabase) {
+        for (item in AppetiteOptionSeed.data) {
+            db.execSQL(
+                sql = """
+                        INSERT INTO appetite_options (description, blocked, active)
+                        VALUES (?, ?, ?)
+                    """.trimIndent(),
+                bindArgs = arrayOf(
+                    item.description,
                     if (item.blocked) 1 else 0,
                     if (item.active) 1 else 0
                 )

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -3,6 +3,7 @@ package io.github.faening.lello.core.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import io.github.faening.lello.core.database.dao.AppetiteOptionDao
 import io.github.faening.lello.core.database.dao.ClimateOptionDao
 import io.github.faening.lello.core.database.dao.EmotionOptionDao
 import io.github.faening.lello.core.database.dao.HealthOptionDao
@@ -14,6 +15,7 @@ import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
 import io.github.faening.lello.core.database.dao.SocialOptionDao
 import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
 import io.github.faening.lello.core.database.model.ClimateOptionEntity
+import io.github.faening.lello.core.database.model.AppetiteOptionEntity
 import io.github.faening.lello.core.database.model.EmotionOptionEntity
 import io.github.faening.lello.core.database.model.HealthOptionEntity
 import io.github.faening.lello.core.database.model.JournalCategoryEntity
@@ -35,6 +37,7 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
 @Database(
     entities = [
         JournalCategoryEntity::class,
+        AppetiteOptionEntity::class,
         ClimateOptionEntity::class,
         EmotionOptionEntity::class,
         HealthOptionEntity::class,
@@ -65,6 +68,7 @@ abstract class LelloDatabase : RoomDatabase() {
     abstract fun journalCategoryDao(): JournalCategoryDao
 
     // options
+    abstract fun appetiteOptionDao(): AppetiteOptionDao
     abstract fun climateOptionDao(): ClimateOptionDao
     abstract fun emotionOptionDao(): EmotionOptionDao
     abstract fun healthOptionDao(): HealthOptionDao

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/AppetiteOptionDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/AppetiteOptionDao.kt
@@ -1,0 +1,58 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import io.github.faening.lello.core.database.model.AppetiteOptionEntity
+import io.github.faening.lello.core.domain.repository.OptionResources
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("unused")
+@Dao
+interface AppetiteOptionDao : OptionResources<AppetiteOptionEntity> {
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM appetite_options
+            WHERE
+                CASE WHEN :useBlockedFilter
+                    THEN blocked = :isBlocked
+                    ELSE 1 END
+            AND
+                CASE WHEN :useActiveFilter
+                    THEN active = :isActive
+                    ELSE 1 END
+            ORDER BY description ASC
+        """
+    )
+    override fun getAll(
+        useBlockedFilter: Boolean,
+        isBlocked: Boolean,
+        useActiveFilter: Boolean,
+        isActive: Boolean
+    ): Flow<List<AppetiteOptionEntity>>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM appetite_options
+            WHERE appetiteOptionId = :id
+            LIMIT 1
+        """
+    )
+    override fun getById(id: Long): Flow<AppetiteOptionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    override suspend fun insert(item: AppetiteOptionEntity): Long
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun update(item: AppetiteOptionEntity)
+
+    @Delete
+    override suspend fun delete(item: AppetiteOptionEntity)
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -27,6 +27,11 @@ internal object DaoModule {
     // region: Options
 
     @Provides
+    fun provideAppetiteOptionDao(
+        database: LelloDatabase,
+    ) = database.appetiteOptionDao()
+
+    @Provides
     fun provideClimateDao(
         database: LelloDatabase,
     ) = database.climateOptionDao()

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/AppetiteOptionEntity.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/AppetiteOptionEntity.kt
@@ -1,0 +1,27 @@
+package io.github.faening.lello.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import io.github.faening.lello.core.model.journal.AppetiteOption
+
+@Entity(tableName = "appetite_options")
+data class AppetiteOptionEntity(
+    @PrimaryKey(autoGenerate = true) val appetiteOptionId: Long,
+    override val description: String,
+    override val blocked: Boolean,
+    override val active: Boolean
+) : OptionEntity()
+
+fun AppetiteOptionEntity.toModel() = AppetiteOption(
+    id = appetiteOptionId,
+    description = description,
+    blocked = blocked,
+    active = active
+)
+
+fun AppetiteOption.toEntity() = AppetiteOptionEntity(
+    appetiteOptionId = id,
+    description = description,
+    blocked = blocked,
+    active = active
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/seed/AppetiteOptionSeed.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/seed/AppetiteOptionSeed.kt
@@ -1,0 +1,23 @@
+package io.github.faening.lello.core.database.seed
+
+import io.github.faening.lello.core.database.model.AppetiteOptionEntity
+
+object AppetiteOptionSeed : Seed<AppetiteOptionEntity> {
+    override val data = listOf(
+        AppetiteOptionEntity(appetiteOptionId = 1, description = "Ausente de fome", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 2, description = "Elevado", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 3, description = "Reduzido", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 4, description = "Desejo específico (gula)", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 5, description = "Fome constante", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 6, description = "Fome emocional", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 7, description = "Fome física", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 8, description = "Mais que o habitual", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 9, description = "Fome matinal", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 10, description = "Fome tardia", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 11, description = "Igual ao habitual", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 12, description = "Menos que o habitual", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 13, description = "Rebeldia alimentar", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 14, description = "Saciedade rápida", blocked = true, active = true),
+        AppetiteOptionEntity(appetiteOptionId = 15, description = "Vontade de beliscar", blocked = true, active = true)
+    )
+}

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/AppetiteOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/AppetiteOption.kt
@@ -1,0 +1,9 @@
+package io.github.faening.lello.core.model.journal
+
+data class AppetiteOption(
+    override val id: Long = 0L,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true,
+    override val selected: Boolean = false
+) : JournalOption


### PR DESCRIPTION
## Summary
- add AppetiteOption model and entity with mappings
- create AppetiteOptionDao and seed data
- register AppetiteOption in database, DAO module, and database seeder

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a43011694832c94651f87a975d969