### PR TITLE
LEL-014 feat(core/database): add `FoodOption` into database layer

### DIFF
--- a/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
@@ -5,6 +5,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import io.github.faening.lello.core.database.seed.AppetiteOptionSeed
 import io.github.faening.lello.core.database.seed.ClimateOptionSeed
 import io.github.faening.lello.core.database.seed.EmotionOptionSeed
+import io.github.faening.lello.core.database.seed.FoodOptionSeed
 import io.github.faening.lello.core.database.seed.HealthOptionSeed
 import io.github.faening.lello.core.database.seed.JournalCategorySeed
 import io.github.faening.lello.core.database.seed.LocationOptionSeed
@@ -33,6 +34,7 @@ internal object DatabaseSeeder {
         seedAppetiteOptions(db)
         seedClimateOptions(db)
         seedEmotionOptions(db)
+        seedFoodOptions(db)
         seedHealthOptions(db)
         seedLocationOptions(db)
         seedMealOptions(db)
@@ -99,6 +101,22 @@ fun seedJournalCategory(db: SupportSQLiteDatabase) {
             db.execSQL(
                 sql = """
                         INSERT INTO emotion_options (description, blocked, active)
+                        VALUES (?, ?, ?)
+                    """.trimIndent(),
+                bindArgs = arrayOf(
+                    item.description,
+                    if (item.blocked) 1 else 0,
+                    if (item.active) 1 else 0
+                )
+            )
+        }
+    }
+
+    fun seedFoodOptions(db: SupportSQLiteDatabase) {
+        for (item in FoodOptionSeed.data) {
+            db.execSQL(
+                sql = """
+                        INSERT INTO food_options (description, blocked, active)
                         VALUES (?, ?, ?)
                     """.trimIndent(),
                 bindArgs = arrayOf(

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.TypeConverters
 import io.github.faening.lello.core.database.dao.AppetiteOptionDao
 import io.github.faening.lello.core.database.dao.ClimateOptionDao
 import io.github.faening.lello.core.database.dao.EmotionOptionDao
+import io.github.faening.lello.core.database.dao.FoodOptionDao
 import io.github.faening.lello.core.database.dao.HealthOptionDao
 import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
@@ -18,6 +19,7 @@ import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
 import io.github.faening.lello.core.database.model.ClimateOptionEntity
 import io.github.faening.lello.core.database.model.AppetiteOptionEntity
 import io.github.faening.lello.core.database.model.EmotionOptionEntity
+import io.github.faening.lello.core.database.model.FoodOptionEntity
 import io.github.faening.lello.core.database.model.HealthOptionEntity
 import io.github.faening.lello.core.database.model.JournalCategoryEntity
 import io.github.faening.lello.core.database.model.LocationOptionEntity
@@ -42,6 +44,7 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
         AppetiteOptionEntity::class,
         ClimateOptionEntity::class,
         EmotionOptionEntity::class,
+        FoodOptionEntity::class,
         HealthOptionEntity::class,
         LocationOptionEntity::class,
         MealOptionEntity::class,
@@ -75,6 +78,7 @@ abstract class LelloDatabase : RoomDatabase() {
     abstract fun appetiteOptionDao(): AppetiteOptionDao
     abstract fun climateOptionDao(): ClimateOptionDao
     abstract fun emotionOptionDao(): EmotionOptionDao
+    abstract fun foodOptionDao(): FoodOptionDao
     abstract fun healthOptionDao(): HealthOptionDao
     abstract fun locationOptionDao() : LocationOptionDao
     abstract fun mealOptionDao(): MealOptionDao

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/FoodOptionDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/FoodOptionDao.kt
@@ -1,0 +1,58 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import io.github.faening.lello.core.database.model.FoodOptionEntity
+import io.github.faening.lello.core.domain.repository.OptionResources
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("unused")
+@Dao
+interface FoodOptionDao : OptionResources<FoodOptionEntity> {
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM food_options
+            WHERE
+                CASE WHEN :useBlockedFilter
+                    THEN blocked = :isBlocked
+                    ELSE 1 END
+            AND
+                CASE WHEN :useActiveFilter
+                    THEN active = :isActive
+                    ELSE 1 END
+            ORDER BY description ASC
+        """
+    )
+    override fun getAll(
+        useBlockedFilter: Boolean,
+        isBlocked: Boolean,
+        useActiveFilter: Boolean,
+        isActive: Boolean,
+    ): Flow<List<FoodOptionEntity>>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM food_options
+            WHERE foodOptionId = :id
+            LIMIT 1
+        """
+    )
+    override fun getById(id: Long): Flow<FoodOptionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    override suspend fun insert(item: FoodOptionEntity): Long
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun update(item: FoodOptionEntity)
+
+    @Delete
+    override suspend fun delete(item: FoodOptionEntity)
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -42,6 +42,11 @@ internal object DaoModule {
     ) = database.emotionOptionDao()
 
     @Provides
+    fun provideFoodOptionDao(
+        database: LelloDatabase,
+    ) = database.foodOptionDao()
+
+    @Provides
     fun provideHealthOptionDao(
         database: LelloDatabase,
     ) = database.healthOptionDao()

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/FoodOptionEntity.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/FoodOptionEntity.kt
@@ -1,0 +1,27 @@
+package io.github.faening.lello.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import io.github.faening.lello.core.model.journal.FoodOption
+
+@Entity(tableName = "food_options")
+data class FoodOptionEntity(
+    @PrimaryKey(autoGenerate = true) val foodOptionId: Long,
+    override val description: String,
+    override val blocked: Boolean,
+    override val active: Boolean,
+) : OptionEntity()
+
+fun FoodOptionEntity.toModel() = FoodOption(
+    id = foodOptionId,
+    description = description,
+    blocked = blocked,
+    active = active,
+)
+
+fun FoodOption.toEntity() = FoodOptionEntity(
+    foodOptionId = id,
+    description = description,
+    blocked = blocked,
+    active = active,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/seed/FoodOptionSeed.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/seed/FoodOptionSeed.kt
@@ -1,0 +1,18 @@
+package io.github.faening.lello.core.database.seed
+
+import io.github.faening.lello.core.database.model.FoodOptionEntity
+
+object FoodOptionSeed : Seed<FoodOptionEntity> {
+    override val data = listOf(
+        FoodOptionEntity(foodOptionId = 1, description = "Caseira", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 2, description = "Doces", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 3, description = "Fast food", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 4, description = "Japonesa", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 5, description = "Mexicana", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 6, description = "Saudável", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 7, description = "Sobremesa", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 8, description = "Salgados", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 9, description = "Vegana", blocked = true, active = true),
+        FoodOptionEntity(foodOptionId = 10, description = "Vegetariana", blocked = true, active = true),
+    )
+}

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/FoodOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/FoodOption.kt
@@ -1,0 +1,9 @@
+package io.github.faening.lello.core.model.journal
+
+data class FoodOption(
+    override val id: Long = 0L,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true,
+    override val selected: Boolean = false,
+) : JournalOption


### PR DESCRIPTION
## Summary
- add `FoodOption` model
- create `FoodOptionEntity` with converters
- implement `FoodOptionDao`
- inject `FoodOptionDao` via `DaoModule`
- seed `FoodOptionEntity` records and add seeding logic
- register entity and dao in `LelloDatabase`

## Testing
- `./gradlew :core:database:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a45a01574832cab47c1b7ad7bed40