### PR TITLE
LEL-014 feat(core/database): add `PortionOption` into database layer

### DIFF
--- a/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
@@ -9,6 +9,7 @@ import io.github.faening.lello.core.database.seed.HealthOptionSeed
 import io.github.faening.lello.core.database.seed.JournalCategorySeed
 import io.github.faening.lello.core.database.seed.LocationOptionSeed
 import io.github.faening.lello.core.database.seed.MealOptionSeed
+import io.github.faening.lello.core.database.seed.PortionOptionSeed
 import io.github.faening.lello.core.database.seed.SensationOptionSeed
 import io.github.faening.lello.core.database.seed.SleepActivityOptionSeed
 import io.github.faening.lello.core.database.seed.SleepQualityOptionSeed
@@ -36,6 +37,7 @@ internal object DatabaseSeeder {
         seedHealthOptions(db)
         seedLocationOptions(db)
         seedMealOptions(db)
+        seedPortionOptions(db)
         seedSensationOptions(db)
         seedSleepActivityOptions(db)
         seedSleepQualityOptions(db)
@@ -126,11 +128,28 @@ fun seedJournalCategory(db: SupportSQLiteDatabase) {
         }
     }
 
+
     fun seedLocationOptions(db: SupportSQLiteDatabase) {
         for (item in LocationOptionSeed.data) {
             db.execSQL(
                 sql = """
                         INSERT INTO location_options (description, blocked, active)
+                        VALUES (?, ?, ?)
+                    """.trimIndent(),
+                bindArgs = arrayOf(
+                    item.description,
+                    if (item.blocked) 1 else 0,
+                    if (item.active) 1 else 0
+                )
+            )
+        }
+    }
+
+    fun seedPortionOptions(db: SupportSQLiteDatabase) {
+        for (item in PortionOptionSeed.data) {
+            db.execSQL(
+                sql = """
+                        INSERT INTO portion_options (description, blocked, active)
                         VALUES (?, ?, ?)
                     """.trimIndent(),
                 bindArgs = arrayOf(

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -10,6 +10,7 @@ import io.github.faening.lello.core.database.dao.HealthOptionDao
 import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
 import io.github.faening.lello.core.database.dao.MealOptionDao
+import io.github.faening.lello.core.database.dao.PortionOptionDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
 import io.github.faening.lello.core.database.dao.SensationOptionDao
 import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
@@ -22,6 +23,7 @@ import io.github.faening.lello.core.database.model.HealthOptionEntity
 import io.github.faening.lello.core.database.model.JournalCategoryEntity
 import io.github.faening.lello.core.database.model.LocationOptionEntity
 import io.github.faening.lello.core.database.model.MealOptionEntity
+import io.github.faening.lello.core.database.model.PortionOptionEntity
 import io.github.faening.lello.core.database.model.MoodJournalEntity
 import io.github.faening.lello.core.database.model.MoodJournalEntityClimateOptionEntityCrossRef
 import io.github.faening.lello.core.database.model.MoodJournalEntityEmotionOptionEntityCrossRef
@@ -45,6 +47,7 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
         HealthOptionEntity::class,
         LocationOptionEntity::class,
         MealOptionEntity::class,
+        PortionOptionEntity::class,
         SocialOptionEntity::class,
         SensationOptionEntity::class,
         SleepActivityOptionEntity::class,
@@ -78,6 +81,7 @@ abstract class LelloDatabase : RoomDatabase() {
     abstract fun healthOptionDao(): HealthOptionDao
     abstract fun locationOptionDao() : LocationOptionDao
     abstract fun mealOptionDao(): MealOptionDao
+    abstract fun portionOptionDao(): PortionOptionDao
     abstract fun sensationOptionDao() : SensationOptionDao
     abstract fun sleepActivityOptionDao() : SleepActivityOptionDao
     abstract fun sleepQualityOptionDao(): SleepQualityOptionDao

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/PortionOptionDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/PortionOptionDao.kt
@@ -1,0 +1,59 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import io.github.faening.lello.core.database.model.PortionOptionEntity
+import io.github.faening.lello.core.domain.repository.OptionResources
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("unused")
+@Dao
+interface PortionOptionDao : OptionResources<PortionOptionEntity> {
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM portion_options
+            WHERE
+                CASE WHEN :useBlockedFilter
+                    THEN blocked = :isBlocked
+                    ELSE 1 END
+            AND
+                CASE WHEN :useActiveFilter
+                    THEN active = :isActive
+                    ELSE 1 END
+            ORDER BY description ASC
+        """
+    )
+    override fun getAll(
+        useBlockedFilter: Boolean,
+        isBlocked: Boolean,
+        useActiveFilter: Boolean,
+        isActive: Boolean,
+    ): Flow<List<PortionOptionEntity>>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM portion_options
+            WHERE portionOptionId = :id
+            LIMIT 1
+        """
+    )
+    override fun getById(id: Long): Flow<PortionOptionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    override suspend fun insert(item: PortionOptionEntity): Long
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun update(item: PortionOptionEntity)
+
+    @Delete
+    override suspend fun delete(item: PortionOptionEntity)
+}
+

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -55,6 +55,11 @@ internal object DaoModule {
     fun provideMealOptionDao(
         database: LelloDatabase,
     ) = database.mealOptionDao()
+
+    @Provides
+    fun providePortionOptionDao(
+        database: LelloDatabase,
+    ) = database.portionOptionDao()
     
     fun provideSensationOptionDao(
         database: LelloDatabase,

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/PortionOptionEntity.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/PortionOptionEntity.kt
@@ -1,0 +1,28 @@
+package io.github.faening.lello.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import io.github.faening.lello.core.model.journal.PortionOption
+
+@Entity(tableName = "portion_options")
+data class PortionOptionEntity(
+    @PrimaryKey(autoGenerate = true) val portionOptionId: Long,
+    override val description: String,
+    override val blocked: Boolean,
+    override val active: Boolean
+) : OptionEntity()
+
+fun PortionOptionEntity.toModel() = PortionOption(
+    id = portionOptionId,
+    description = description,
+    blocked = blocked,
+    active = active,
+)
+
+fun PortionOption.toEntity() = PortionOptionEntity(
+    portionOptionId = id,
+    description = description,
+    blocked = blocked,
+    active = active,
+)
+

--- a/core/database/src/main/java/io/github/faening/lello/core/database/seed/PortionOptionSeed.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/seed/PortionOptionSeed.kt
@@ -1,0 +1,17 @@
+package io.github.faening.lello.core.database.seed
+
+import io.github.faening.lello.core.database.model.PortionOptionEntity
+
+object PortionOptionSeed : Seed<PortionOptionEntity> {
+    override val data = listOf(
+        PortionOptionEntity(portionOptionId = 1, description = "Copo", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 2, description = "Fatia", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 3, description = "Porção pequena", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 4, description = "Porção média", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 5, description = "Porção grande", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 6, description = "Prato", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 7, description = "Tigela", blocked = true, active = true),
+        PortionOptionEntity(portionOptionId = 8, description = "Livre (à vontade)", blocked = true, active = true),
+    )
+}
+

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/PortionOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/PortionOption.kt
@@ -1,0 +1,10 @@
+package io.github.faening.lello.core.model.journal
+
+data class PortionOption(
+    override val id: Long = 0L,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true,
+    override val selected: Boolean = false,
+) : JournalOption
+


### PR DESCRIPTION
## Summary
- add PortionOptionEntity with mapping helpers
- introduce PortionOption data model
- create PortionOptionDao
- register PortionOptionDao/Entity in LelloDatabase and DaoModule
- seed default PortionOption values and add seeding logic
- fix indentation in DatabaseSeeder

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a47191000832c99601e969d46dda7