### PR TITLE
LEL-014 feat(core/database): add `DosageFormOption` into database layer

### DIFF
--- a/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/DatabaseSeeder.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.sqlite.db.SupportSQLiteDatabase
 import io.github.faening.lello.core.database.seed.AppetiteOptionSeed
 import io.github.faening.lello.core.database.seed.ClimateOptionSeed
+import io.github.faening.lello.core.database.seed.DosageFormOptionSeed
 import io.github.faening.lello.core.database.seed.EmotionOptionSeed
 import io.github.faening.lello.core.database.seed.FoodOptionSeed
 import io.github.faening.lello.core.database.seed.HealthOptionSeed
@@ -33,6 +34,7 @@ internal object DatabaseSeeder {
         seedJournalCategory(db)
         seedAppetiteOptions(db)
         seedClimateOptions(db)
+        seedDosageFormOptions(db)
         seedEmotionOptions(db)
         seedFoodOptions(db)
         seedHealthOptions(db)
@@ -80,11 +82,27 @@ fun seedJournalCategory(db: SupportSQLiteDatabase) {
         }
     }
 
-    fun seedClimateOptions(db: SupportSQLiteDatabase) {
+fun seedClimateOptions(db: SupportSQLiteDatabase) {
         for (item in ClimateOptionSeed.data) {
             db.execSQL(
                 sql = """
                         INSERT INTO climate_options (description, blocked, active)
+                        VALUES (?, ?, ?)
+                    """.trimIndent(),
+                bindArgs = arrayOf(
+                    item.description,
+                    if (item.blocked) 1 else 0,
+                    if (item.active) 1 else 0
+                )
+            )
+        }
+    }
+
+    fun seedDosageFormOptions(db: SupportSQLiteDatabase) {
+        for (item in DosageFormOptionSeed.data) {
+            db.execSQL(
+                sql = """
+                        INSERT INTO dosage_form_options (description, blocked, active)
                         VALUES (?, ?, ?)
                     """.trimIndent(),
                 bindArgs = arrayOf(

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import io.github.faening.lello.core.database.dao.AppetiteOptionDao
 import io.github.faening.lello.core.database.dao.ClimateOptionDao
+import io.github.faening.lello.core.database.dao.DosageFormOptionDao
 import io.github.faening.lello.core.database.dao.EmotionOptionDao
 import io.github.faening.lello.core.database.dao.FoodOptionDao
 import io.github.faening.lello.core.database.dao.HealthOptionDao
@@ -17,6 +18,7 @@ import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
 import io.github.faening.lello.core.database.dao.SocialOptionDao
 import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
 import io.github.faening.lello.core.database.model.ClimateOptionEntity
+import io.github.faening.lello.core.database.model.DosageFormOptionEntity
 import io.github.faening.lello.core.database.model.AppetiteOptionEntity
 import io.github.faening.lello.core.database.model.EmotionOptionEntity
 import io.github.faening.lello.core.database.model.FoodOptionEntity
@@ -43,6 +45,7 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
         JournalCategoryEntity::class,
         AppetiteOptionEntity::class,
         ClimateOptionEntity::class,
+        DosageFormOptionEntity::class,
         EmotionOptionEntity::class,
         FoodOptionEntity::class,
         HealthOptionEntity::class,
@@ -77,6 +80,7 @@ abstract class LelloDatabase : RoomDatabase() {
     // options
     abstract fun appetiteOptionDao(): AppetiteOptionDao
     abstract fun climateOptionDao(): ClimateOptionDao
+    abstract fun dosageFormOptionDao(): DosageFormOptionDao
     abstract fun emotionOptionDao(): EmotionOptionDao
     abstract fun foodOptionDao(): FoodOptionDao
     abstract fun healthOptionDao(): HealthOptionDao

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/DosageFormOptionDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/DosageFormOptionDao.kt
@@ -1,0 +1,58 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import io.github.faening.lello.core.database.model.DosageFormOptionEntity
+import io.github.faening.lello.core.domain.repository.OptionResources
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("unused")
+@Dao
+interface DosageFormOptionDao : OptionResources<DosageFormOptionEntity> {
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM dosage_form_options
+            WHERE
+                CASE WHEN :useBlockedFilter
+                    THEN blocked = :isBlocked
+                    ELSE 1 END
+            AND
+                CASE WHEN :useActiveFilter
+                    THEN active = :isActive
+                    ELSE 1 END
+            ORDER BY description ASC
+        """
+    )
+    override fun getAll(
+        useBlockedFilter: Boolean,
+        isBlocked: Boolean,
+        useActiveFilter: Boolean,
+        isActive: Boolean
+    ): Flow<List<DosageFormOptionEntity>>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM dosage_form_options
+            WHERE dosageFormOptionId = :id
+            LIMIT 1
+        """
+    )
+    override fun getById(id: Long): Flow<DosageFormOptionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    override suspend fun insert(item: DosageFormOptionEntity): Long
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun update(item: DosageFormOptionEntity)
+
+    @Delete
+    override suspend fun delete(item: DosageFormOptionEntity)
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -37,6 +37,11 @@ internal object DaoModule {
     ) = database.climateOptionDao()
 
     @Provides
+    fun provideDosageFormOptionDao(
+        database: LelloDatabase,
+    ) = database.dosageFormOptionDao()
+
+    @Provides
     fun provideEmotionDao(
         database: LelloDatabase,
     ) = database.emotionOptionDao()

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/DosageFormOptionEntity.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/DosageFormOptionEntity.kt
@@ -1,0 +1,27 @@
+package io.github.faening.lello.core.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import io.github.faening.lello.core.model.journal.DosageFormOption
+
+@Entity(tableName = "dosage_form_options")
+data class DosageFormOptionEntity(
+    @PrimaryKey(autoGenerate = true) val dosageFormOptionId: Long,
+    override val description: String,
+    override val blocked: Boolean,
+    override val active: Boolean
+) : OptionEntity()
+
+fun DosageFormOptionEntity.toModel() = DosageFormOption(
+    id = dosageFormOptionId,
+    description = description,
+    blocked = blocked,
+    active = active
+)
+
+fun DosageFormOption.toEntity() = DosageFormOptionEntity(
+    dosageFormOptionId = id,
+    description = description,
+    blocked = blocked,
+    active = active
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/seed/DosageFormOptionSeed.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/seed/DosageFormOptionSeed.kt
@@ -1,0 +1,32 @@
+package io.github.faening.lello.core.database.seed
+
+import io.github.faening.lello.core.database.model.DosageFormOptionEntity
+
+object DosageFormOptionSeed : Seed<DosageFormOptionEntity> {
+    override val data = listOf(
+        DosageFormOptionEntity(dosageFormOptionId = 1, description = "Ampola", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 2, description = "Anel", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 3, description = "Cápsula", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 4, description = "Cápsula gelatinosa", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 5, description = "Chá", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 6, description = "Comprimido", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 7, description = "Comprimido mastigável", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 8, description = "Comprimido sublingual", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 9, description = "Creme", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 10, description = "Curativo", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 11, description = "Drágea", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 12, description = "Espuma", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 13, description = "Gel", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 14, description = "Goma", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 15, description = "Inalador", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 16, description = "Injeção", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 17, description = "Loção", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 18, description = "Pasta de dente", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 19, description = "Pomada", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 20, description = "Pó", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 21, description = "Shampoo", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 22, description = "Spray", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 23, description = "Supositório", blocked = true, active = true),
+        DosageFormOptionEntity(dosageFormOptionId = 24, description = "Xarope", blocked = true, active = true)
+    )
+}

--- a/core/model/src/main/java/io/github/faening/lello/core/model/journal/DosageFormOption.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/journal/DosageFormOption.kt
@@ -1,0 +1,9 @@
+package io.github.faening.lello.core.model.journal
+
+data class DosageFormOption(
+    override val id: Long = 0L,
+    override val description: String,
+    override val blocked: Boolean = false,
+    override val active: Boolean = true,
+    override val selected: Boolean = false
+) : JournalOption


### PR DESCRIPTION
## Summary
- add `DosageFormOptionEntity` and mappings
- create `DosageFormOption` model
- implement DAO and seed for dosage form options
- register entity and dao in `LelloDatabase` and `DaoModule`
- seed dosage form options through `DatabaseSeeder`

## Testing
- `./gradlew :core:database:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a48e6550c832c8de930228a4fcc2e