### PR TITLE
LEL-015 test(authenticate): add unit tests for authentication use cases

### DIFF
--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     api(projects.core.model)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/GetCurrentUserUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/GetCurrentUserUseCaseTest.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.domain.usecase.authentication
+
+import io.github.faening.lello.core.domain.repository.AuthenticationRepository
+import io.github.faening.lello.core.model.authentication.User
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetCurrentUserUseCaseTest {
+    private val repository: AuthenticationRepository = mockk()
+    private val useCase = GetCurrentUserUseCase(repository)
+
+    @Test
+    fun `invoke should return flow from repository`() = runTest {
+        val user = User(id = "1", email = "test@example.com", displayName = null, photoUrl = null)
+        val flow = flowOf(user)
+        every { repository.getCurrentUser() } returns flow
+
+        val result = useCase().first()
+
+        assertEquals(user, result)
+        verify(exactly = 1) { repository.getCurrentUser() }
+    }
+}

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SendPasswordResetEmailUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SendPasswordResetEmailUseCaseTest.kt
@@ -1,0 +1,34 @@
+package io.github.faening.lello.core.domain.usecase.authentication
+
+import io.github.faening.lello.core.domain.repository.AuthenticationRepository
+import io.github.faening.lello.core.model.authentication.AuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SendPasswordResetEmailUseCaseTest {
+    private val repository: AuthenticationRepository = mockk()
+    private val useCase = SendPasswordResetEmailUseCase(repository)
+
+    @Test
+    fun `blank email returns error`() = runTest {
+        val result = useCase("")
+        assertTrue(result is AuthResult.Error)
+        assertEquals("Email não pode estar vazio", (result as AuthResult.Error).message)
+        coVerify(exactly = 0) { repository.sendPasswordResetEmail(any()) }
+    }
+
+    @Test
+    fun `valid email calls repository`() = runTest {
+        coEvery { repository.sendPasswordResetEmail("test@example.com") } returns AuthResult.Success(Unit)
+
+        val result = useCase("test@example.com")
+
+        assertTrue(result is AuthResult.Success)
+        coVerify(exactly = 1) { repository.sendPasswordResetEmail("test@example.com") }
+    }
+}

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignInUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignInUseCaseTest.kt
@@ -1,0 +1,34 @@
+package io.github.faening.lello.core.domain.usecase.authentication
+
+import io.github.faening.lello.core.domain.repository.AuthenticationRepository
+import io.github.faening.lello.core.model.authentication.AuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignInUseCaseTest {
+    private val repository: AuthenticationRepository = mockk()
+    private val useCase = SignInUseCase(repository)
+
+    @Test
+    fun `blank credentials returns error`() = runTest {
+        val result = useCase("", "")
+        assertTrue(result is AuthResult.Error)
+        assertEquals("Email e senha não podem estar vazios", (result as AuthResult.Error).message)
+        coVerify(exactly = 0) { repository.signInWithEmailAndPassword(any(), any()) }
+    }
+
+    @Test
+    fun `valid credentials returns success`() = runTest {
+        coEvery { repository.signInWithEmailAndPassword("test@example.com", "123456") } returns AuthResult.Success(Unit)
+
+        val result = useCase("test@example.com", "123456")
+
+        assertTrue(result is AuthResult.Success)
+        coVerify(exactly = 1) { repository.signInWithEmailAndPassword("test@example.com", "123456") }
+    }
+}

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignOutUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignOutUseCaseTest.kt
@@ -1,0 +1,25 @@
+package io.github.faening.lello.core.domain.usecase.authentication
+
+import io.github.faening.lello.core.domain.repository.AuthenticationRepository
+import io.github.faening.lello.core.model.authentication.AuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignOutUseCaseTest {
+    private val repository: AuthenticationRepository = mockk()
+    private val useCase = SignOutUseCase(repository)
+
+    @Test
+    fun `invoke should call repository`() = runTest {
+        coEvery { repository.signOut() } returns AuthResult.Success(Unit)
+
+        val result = useCase()
+
+        assertTrue(result is AuthResult.Success)
+        coVerify(exactly = 1) { repository.signOut() }
+    }
+}

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignUpUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/authentication/SignUpUseCaseTest.kt
@@ -1,0 +1,42 @@
+package io.github.faening.lello.core.domain.usecase.authentication
+
+import io.github.faening.lello.core.domain.repository.AuthenticationRepository
+import io.github.faening.lello.core.model.authentication.AuthResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignUpUseCaseTest {
+    private val repository: AuthenticationRepository = mockk()
+    private val useCase = SignUpUseCase(repository)
+
+    @Test
+    fun `blank credentials returns error`() = runTest {
+        val result = useCase("", "")
+        assertTrue(result is AuthResult.Error)
+        assertEquals("Email e senha não podem estar vazios", (result as AuthResult.Error).message)
+        coVerify(exactly = 0) { repository.signUpWithEmailAndPassword(any(), any()) }
+    }
+
+    @Test
+    fun `short password returns error`() = runTest {
+        val result = useCase("test@example.com", "12345")
+        assertTrue(result is AuthResult.Error)
+        assertEquals("A senha deve ter pelo menos 6 caracteres", (result as AuthResult.Error).message)
+        coVerify(exactly = 0) { repository.signUpWithEmailAndPassword(any(), any()) }
+    }
+
+    @Test
+    fun `valid credentials returns success`() = runTest {
+        coEvery { repository.signUpWithEmailAndPassword("test@example.com", "123456") } returns AuthResult.Success(Unit)
+
+        val result = useCase("test@example.com", "123456")
+
+        assertTrue(result is AuthResult.Success)
+        coVerify(exactly = 1) { repository.signUpWithEmailAndPassword("test@example.com", "123456") }
+    }
+}

--- a/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/options/ClimateOptionUseCaseTest.kt
+++ b/core/domain/src/test/java/io/github/faening/lello/core/domain/usecase/options/ClimateOptionUseCaseTest.kt
@@ -1,0 +1,47 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.mock.ClimateOptionMock
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.model.journal.ClimateOption
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClimateOptionUseCaseTest {
+    private val repository: OptionResources<ClimateOption> = mockk()
+    private val useCase = ClimateOptionUseCase(repository)
+
+    @Test
+    fun `getAll should delegate to repository`() = runTest {
+        val expected = ClimateOptionMock.list
+        every { repository.getAll(false, true, false, true) } returns flowOf(expected)
+
+        val result = useCase.getAll().first()
+
+        assertEquals(expected, result)
+        coVerify(exactly = 0) { repository.insert(any()) }
+        verify(exactly = 1) { repository.getAll(false, true, false, true) }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getById with invalid id throws`() {
+        useCase.getById(0L)
+    }
+
+    @Test
+    fun `save formats description and inserts`() = runTest {
+        val option = ClimateOption(id = 0, description = "nublado")
+        coEvery { repository.insert(any()) } returns 1L
+
+        useCase.save(option)
+
+        coVerify(exactly = 1) { repository.insert(option.copy(description = "Nublado")) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ test-junit = "1.2.1"
 test-rules = "1.6.1"
 test-runner = "1.6.2"
 work = "2.10.0"
+mockk = "1.14.2"
 
 [libraries]
 androidx-compose-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
@@ -105,6 +106,7 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlin-datetime" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlin-serialization-json" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 # Lifecycle
 # https://developer.android.com/jetpack/androidx/releases/lifecycle?hl=pt-br


### PR DESCRIPTION
## Summary
- add mockk library to libs catalog
- update core.domain test dependencies
- add unit tests for authentication and option usecases

## Testing
- `./gradlew :core:domain:test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aead60ee0832ca46fe29a9b05b7ec