### PR TITLE
LEL-014 feat(core/data): add option repositories and use cases

### DIFF
--- a/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
@@ -4,29 +4,53 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.github.faening.lello.core.data.repository.AppetiteOptionRepository
 import io.github.faening.lello.core.data.repository.ClimateOptionRepository
+import io.github.faening.lello.core.data.repository.DosageFormOptionRepository
 import io.github.faening.lello.core.data.repository.EmotionOptionRepository
+import io.github.faening.lello.core.data.repository.FoodOptionRepository
 import io.github.faening.lello.core.data.repository.HealthOptionRepository
 import io.github.faening.lello.core.data.repository.JournalCategoryRepository
 import io.github.faening.lello.core.data.repository.LocationOptionRepository
+import io.github.faening.lello.core.data.repository.MealOptionRepository
 import io.github.faening.lello.core.data.repository.MoodJournalRepository
+import io.github.faening.lello.core.data.repository.PortionOptionRepository
+import io.github.faening.lello.core.data.repository.SensationOptionRepository
+import io.github.faening.lello.core.data.repository.SleepActivityOptionRepository
+import io.github.faening.lello.core.data.repository.SleepQualityOptionRepository
 import io.github.faening.lello.core.data.repository.SocialOptionRepository
+import io.github.faening.lello.core.database.dao.AppetiteOptionDao
 import io.github.faening.lello.core.database.dao.ClimateOptionDao
+import io.github.faening.lello.core.database.dao.DosageFormOptionDao
 import io.github.faening.lello.core.database.dao.EmotionOptionDao
+import io.github.faening.lello.core.database.dao.FoodOptionDao
 import io.github.faening.lello.core.database.dao.HealthOptionDao
 import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
+import io.github.faening.lello.core.database.dao.MealOptionDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
+import io.github.faening.lello.core.database.dao.PortionOptionDao
+import io.github.faening.lello.core.database.dao.SensationOptionDao
+import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
+import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
 import io.github.faening.lello.core.database.dao.SocialOptionDao
 import io.github.faening.lello.core.domain.repository.JournalCategoryResources
 import io.github.faening.lello.core.domain.repository.MoodJournalResources
 import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.model.journal.AppetiteOption
 import io.github.faening.lello.core.model.journal.ClimateOption
+import io.github.faening.lello.core.model.journal.DosageFormOption
 import io.github.faening.lello.core.model.journal.EmotionOption
+import io.github.faening.lello.core.model.journal.FoodOption
 import io.github.faening.lello.core.model.journal.HealthOption
 import io.github.faening.lello.core.model.journal.JournalCategory
-import io.github.faening.lello.core.model.journal.MoodJournal
 import io.github.faening.lello.core.model.journal.LocationOption
+import io.github.faening.lello.core.model.journal.MealOption
+import io.github.faening.lello.core.model.journal.MoodJournal
+import io.github.faening.lello.core.model.journal.PortionOption
+import io.github.faening.lello.core.model.journal.SensationOption
+import io.github.faening.lello.core.model.journal.SleepActivityOption
+import io.github.faening.lello.core.model.journal.SleepQualityOption
 import io.github.faening.lello.core.model.journal.SocialOption
 
 /**
@@ -64,6 +88,13 @@ object RepositoryModule {
     }
 
     @Provides
+    fun provideAppetiteOptionRepository(
+        dao: AppetiteOptionDao
+    ): OptionResources<AppetiteOption> {
+        return AppetiteOptionRepository(dao)
+    }
+
+    @Provides
     fun provideClimateOptionRepository(
         dao: ClimateOptionDao
     ): OptionResources<ClimateOption> {
@@ -71,10 +102,24 @@ object RepositoryModule {
     }
 
     @Provides
+    fun provideDosageFormOptionRepository(
+        dao: DosageFormOptionDao
+    ): OptionResources<DosageFormOption> {
+        return DosageFormOptionRepository(dao)
+    }
+
+    @Provides
     fun provideEmotionOptionRepository(
         dao: EmotionOptionDao
     ): OptionResources<EmotionOption> {
         return EmotionOptionRepository(dao)
+    }
+
+    @Provides
+    fun provideFoodOptionRepository(
+        dao: FoodOptionDao
+    ): OptionResources<FoodOption> {
+        return FoodOptionRepository(dao)
     }
 
     @Provides
@@ -89,6 +134,41 @@ object RepositoryModule {
         dao: LocationOptionDao
     ) : OptionResources<LocationOption> {
         return LocationOptionRepository(dao)
+    }
+
+    @Provides
+    fun provideMealOptionRepository(
+        dao: MealOptionDao
+    ): OptionResources<MealOption> {
+        return MealOptionRepository(dao)
+    }
+
+    @Provides
+    fun providePortionOptionRepository(
+        dao: PortionOptionDao
+    ): OptionResources<PortionOption> {
+        return PortionOptionRepository(dao)
+    }
+
+    @Provides
+    fun provideSensationOptionRepository(
+        dao: SensationOptionDao
+    ): OptionResources<SensationOption> {
+        return SensationOptionRepository(dao)
+    }
+
+    @Provides
+    fun provideSleepActivityOptionRepository(
+        dao: SleepActivityOptionDao
+    ): OptionResources<SleepActivityOption> {
+        return SleepActivityOptionRepository(dao)
+    }
+
+    @Provides
+    fun provideSleepQualityOptionRepository(
+        dao: SleepQualityOptionDao
+    ): OptionResources<SleepQualityOption> {
+        return SleepQualityOptionRepository(dao)
     }
 
     @Provides

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/AppetiteOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/AppetiteOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.AppetiteOptionDao
+import io.github.faening.lello.core.database.model.option.AppetiteOptionEntity
+import io.github.faening.lello.core.model.journal.AppetiteOption
+import jakarta.inject.Inject
+
+class AppetiteOptionRepository @Inject constructor(
+    dao: AppetiteOptionDao
+) : OptionRepository<AppetiteOption, AppetiteOptionEntity>(dao) {
+
+    override fun AppetiteOptionEntity.toModel(): AppetiteOption {
+        return AppetiteOption(
+            id = this.appetiteOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun AppetiteOption.toEntity(): AppetiteOptionEntity {
+        return AppetiteOptionEntity(
+            appetiteOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/DosageFormOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/DosageFormOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.DosageFormOptionDao
+import io.github.faening.lello.core.database.model.option.DosageFormOptionEntity
+import io.github.faening.lello.core.model.journal.DosageFormOption
+import jakarta.inject.Inject
+
+class DosageFormOptionRepository @Inject constructor(
+    dao: DosageFormOptionDao
+) : OptionRepository<DosageFormOption, DosageFormOptionEntity>(dao) {
+
+    override fun DosageFormOptionEntity.toModel(): DosageFormOption {
+        return DosageFormOption(
+            id = this.dosageFormOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun DosageFormOption.toEntity(): DosageFormOptionEntity {
+        return DosageFormOptionEntity(
+            dosageFormOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/FoodOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/FoodOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.FoodOptionDao
+import io.github.faening.lello.core.database.model.option.FoodOptionEntity
+import io.github.faening.lello.core.model.journal.FoodOption
+import jakarta.inject.Inject
+
+class FoodOptionRepository @Inject constructor(
+    dao: FoodOptionDao
+) : OptionRepository<FoodOption, FoodOptionEntity>(dao) {
+
+    override fun FoodOptionEntity.toModel(): FoodOption {
+        return FoodOption(
+            id = this.foodOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun FoodOption.toEntity(): FoodOptionEntity {
+        return FoodOptionEntity(
+            foodOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/MealOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/MealOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.MealOptionDao
+import io.github.faening.lello.core.database.model.option.MealOptionEntity
+import io.github.faening.lello.core.model.journal.MealOption
+import jakarta.inject.Inject
+
+class MealOptionRepository @Inject constructor(
+    dao: MealOptionDao
+) : OptionRepository<MealOption, MealOptionEntity>(dao) {
+
+    override fun MealOptionEntity.toModel(): MealOption {
+        return MealOption(
+            id = this.mealOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun MealOption.toEntity(): MealOptionEntity {
+        return MealOptionEntity(
+            mealOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/PortionOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/PortionOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.PortionOptionDao
+import io.github.faening.lello.core.database.model.option.PortionOptionEntity
+import io.github.faening.lello.core.model.journal.PortionOption
+import jakarta.inject.Inject
+
+class PortionOptionRepository @Inject constructor(
+    dao: PortionOptionDao
+) : OptionRepository<PortionOption, PortionOptionEntity>(dao) {
+
+    override fun PortionOptionEntity.toModel(): PortionOption {
+        return PortionOption(
+            id = this.portionOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun PortionOption.toEntity(): PortionOptionEntity {
+        return PortionOptionEntity(
+            portionOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/SensationOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/SensationOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.SensationOptionDao
+import io.github.faening.lello.core.database.model.option.SensationOptionEntity
+import io.github.faening.lello.core.model.journal.SensationOption
+import jakarta.inject.Inject
+
+class SensationOptionRepository @Inject constructor(
+    dao: SensationOptionDao
+) : OptionRepository<SensationOption, SensationOptionEntity>(dao) {
+
+    override fun SensationOptionEntity.toModel(): SensationOption {
+        return SensationOption(
+            id = this.sensationOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun SensationOption.toEntity(): SensationOptionEntity {
+        return SensationOptionEntity(
+            sensationOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepActivityOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepActivityOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
+import io.github.faening.lello.core.database.model.option.SleepActivityOptionEntity
+import io.github.faening.lello.core.model.journal.SleepActivityOption
+import jakarta.inject.Inject
+
+class SleepActivityOptionRepository @Inject constructor(
+    dao: SleepActivityOptionDao
+) : OptionRepository<SleepActivityOption, SleepActivityOptionEntity>(dao) {
+
+    override fun SleepActivityOptionEntity.toModel(): SleepActivityOption {
+        return SleepActivityOption(
+            id = this.sleepActivityOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun SleepActivityOption.toEntity(): SleepActivityOptionEntity {
+        return SleepActivityOptionEntity(
+            sleepActivityOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepQualityOptionRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepQualityOptionRepository.kt
@@ -1,0 +1,29 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
+import io.github.faening.lello.core.database.model.option.SleepQualityOptionEntity
+import io.github.faening.lello.core.model.journal.SleepQualityOption
+import jakarta.inject.Inject
+
+class SleepQualityOptionRepository @Inject constructor(
+    dao: SleepQualityOptionDao
+) : OptionRepository<SleepQualityOption, SleepQualityOptionEntity>(dao) {
+
+    override fun SleepQualityOptionEntity.toModel(): SleepQualityOption {
+        return SleepQualityOption(
+            id = this.sleepQualityOptionId,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+
+    override fun SleepQualityOption.toEntity(): SleepQualityOptionEntity {
+        return SleepQualityOptionEntity(
+            sleepQualityOptionId = this.id,
+            description = this.description,
+            blocked = this.blocked,
+            active = this.active
+        )
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/AppetiteOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/AppetiteOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.AppetiteOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class AppetiteOptionUseCase @Inject constructor(
+    private val repository: OptionResources<AppetiteOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<AppetiteOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<AppetiteOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: AppetiteOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: AppetiteOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: AppetiteOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/DosageFormOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/DosageFormOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.DosageFormOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DosageFormOptionUseCase @Inject constructor(
+    private val repository: OptionResources<DosageFormOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<DosageFormOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<DosageFormOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: DosageFormOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: DosageFormOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: DosageFormOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/FoodOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/FoodOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.FoodOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class FoodOptionUseCase @Inject constructor(
+    private val repository: OptionResources<FoodOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<FoodOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<FoodOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: FoodOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: FoodOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: FoodOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/MealOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/MealOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.MealOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class MealOptionUseCase @Inject constructor(
+    private val repository: OptionResources<MealOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<MealOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<MealOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: MealOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: MealOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: MealOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/PortionOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/PortionOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.PortionOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class PortionOptionUseCase @Inject constructor(
+    private val repository: OptionResources<PortionOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<PortionOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<PortionOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: PortionOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: PortionOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: PortionOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SensationOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SensationOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.SensationOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SensationOptionUseCase @Inject constructor(
+    private val repository: OptionResources<SensationOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<SensationOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<SensationOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: SensationOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: SensationOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: SensationOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepActivityOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepActivityOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.SleepActivityOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SleepActivityOptionUseCase @Inject constructor(
+    private val repository: OptionResources<SleepActivityOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<SleepActivityOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<SleepActivityOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: SleepActivityOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: SleepActivityOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: SleepActivityOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepQualityOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepQualityOptionUseCase.kt
@@ -1,0 +1,55 @@
+package io.github.faening.lello.core.domain.usecase.options
+
+import io.github.faening.lello.core.domain.repository.OptionResources
+import io.github.faening.lello.core.domain.util.capitalizeFirst
+import io.github.faening.lello.core.domain.util.validateDescription
+import io.github.faening.lello.core.domain.util.validateId
+import io.github.faening.lello.core.domain.util.validateNotBlocked
+import io.github.faening.lello.core.model.journal.SleepQualityOption
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SleepQualityOptionUseCase @Inject constructor(
+    private val repository: OptionResources<SleepQualityOption>
+) {
+
+    fun getAll(
+        useBlockedFilter: Boolean = false,
+        isBlocked: Boolean = true,
+        useActiveFilter: Boolean = false,
+        isActive: Boolean = true
+    ): Flow<List<SleepQualityOption>> {
+        return repository.getAll(useBlockedFilter, isBlocked, useActiveFilter, isActive)
+    }
+
+    fun getById(id: Long): Flow<SleepQualityOption>? {
+        id.validateId()
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg items: SleepQualityOption) {
+        val formattedItems = items.map { item ->
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.insert(item) }
+    }
+
+    suspend fun update(vararg items: SleepQualityOption) {
+        val formattedItems = items.map { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+            item.description.validateDescription()
+            item.copy(description = item.description.capitalizeFirst())
+        }
+        formattedItems.forEach { item -> repository.update(item) }
+    }
+
+    suspend fun delete(vararg items: SleepQualityOption) {
+        items.forEach { item ->
+            item.blocked.validateNotBlocked()
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.delete(item) }
+    }
+}


### PR DESCRIPTION
## Summary
- implement repositories for appetite, dosage form, food, meal, portion, sensation, sleep activity and sleep quality options
- provide new repositories via `RepositoryModule`
- implement use cases for the new option repositories

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aff2b5150832cb083c526abca788e