### PR TITLE
LEL-014 feat(journal/settings): add `JournalSettingsOptionScreen`

### DIFF
--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsNavigation.kt
@@ -19,6 +19,22 @@ import io.github.faening.lello.feature.journal.settings.screen.social.JournalSet
 import io.github.faening.lello.feature.journal.settings.screen.social.JournalSettingsSocialScreen
 import io.github.faening.lello.feature.journal.settings.screen.health.JournalSettingsHealthRegisterScreen
 import io.github.faening.lello.feature.journal.settings.screen.health.JournalSettingsHealthScreen
+import io.github.faening.lello.feature.journal.settings.screen.appetite.JournalSettingsAppetiteOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.appetite.JournalSettingsAppetiteOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.dosageform.JournalSettingsDosageFormOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.dosageform.JournalSettingsDosageFormOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.food.JournalSettingsFoodOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.food.JournalSettingsFoodOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.meal.JournalSettingsMealOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.meal.JournalSettingsMealOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.portion.JournalSettingsPortionOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.portion.JournalSettingsPortionOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.sensation.JournalSettingsSensationOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.sensation.JournalSettingsSensationOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.sleepactivity.JournalSettingsSleepActivityOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.sleepactivity.JournalSettingsSleepActivityOptionScreen
+import io.github.faening.lello.feature.journal.settings.screen.sleepquality.JournalSettingsSleepQualityOptionRegisterScreen
+import io.github.faening.lello.feature.journal.settings.screen.sleepquality.JournalSettingsSleepQualityOptionScreen
 
 object JournalSettingsDestinations {
     const val GRAPH = "journal_settings_graph"
@@ -32,6 +48,30 @@ object JournalSettingsDestinations {
     const val SOCIAl_REGISTER = "journal_settings_social_register"
     const val HEALTH_SETTINGS = "journal_settings_health/{colorScheme}"
     const val HEALTH_REGISTER = "journal_settings_health_register"
+
+    const val APPETITE_SETTINGS = "journal_settings_appetite/{colorScheme}"
+    const val APPETITE_REGISTER = "journal_settings_appetite_register"
+
+    const val DOSAGE_FORM_SETTINGS = "journal_settings_dosageform/{colorScheme}"
+    const val DOSAGE_FORM_REGISTER = "journal_settings_dosageform_register"
+
+    const val FOOD_SETTINGS = "journal_settings_food/{colorScheme}"
+    const val FOOD_REGISTER = "journal_settings_food_register"
+
+    const val MEAL_SETTINGS = "journal_settings_meal/{colorScheme}"
+    const val MEAL_REGISTER = "journal_settings_meal_register"
+
+    const val PORTION_SETTINGS = "journal_settings_portion/{colorScheme}"
+    const val PORTION_REGISTER = "journal_settings_portion_register"
+
+    const val SENSATION_SETTINGS = "journal_settings_sensation/{colorScheme}"
+    const val SENSATION_REGISTER = "journal_settings_sensation_register"
+
+    const val SLEEP_ACTIVITY_SETTINGS = "journal_settings_sleepactivity/{colorScheme}"
+    const val SLEEP_ACTIVITY_REGISTER = "journal_settings_sleepactivity_register"
+
+    const val SLEEP_QUALITY_SETTINGS = "journal_settings_sleepquality/{colorScheme}"
+    const val SLEEP_QUALITY_REGISTER = "journal_settings_sleepquality_register"
 }
 
 fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
@@ -149,6 +189,190 @@ fun NavGraphBuilder.journalSettingsGraph(navController: NavHostController) {
         composable(JournalSettingsDestinations.HEALTH_REGISTER) { backStackEntry ->
             val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
             JournalSettingsHealthRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.APPETITE_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsAppetiteOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.APPETITE_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.APPETITE_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsAppetiteOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.DOSAGE_FORM_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsDosageFormOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.DOSAGE_FORM_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.DOSAGE_FORM_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsDosageFormOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.FOOD_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsFoodOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.FOOD_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.FOOD_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsFoodOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.MEAL_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsMealOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.MEAL_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.MEAL_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsMealOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.PORTION_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsPortionOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.PORTION_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.PORTION_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsPortionOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.SENSATION_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSensationOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.SENSATION_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.SENSATION_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSensationOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.SLEEP_ACTIVITY_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSleepActivityOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.SLEEP_ACTIVITY_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.SLEEP_ACTIVITY_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSleepActivityOptionRegisterScreen(
+                viewModel = viewModel,
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(JournalSettingsDestinations.SLEEP_QUALITY_SETTINGS) { backStackEntry ->
+            val colorSchemeName = backStackEntry.arguments?.getString("colorScheme")
+            val colorScheme = colorSchemeName
+                ?.let { runCatching { LelloColorScheme.valueOf(it) }.getOrNull() }
+                ?: LelloColorScheme.DEFAULT
+
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSleepQualityOptionScreen(
+                viewModel = viewModel,
+                colorScheme = colorScheme,
+                onBack = { navController.popBackStack() },
+                onRegister = { navController.navigate(JournalSettingsDestinations.SLEEP_QUALITY_REGISTER) }
+            )
+        }
+
+        composable(JournalSettingsDestinations.SLEEP_QUALITY_REGISTER) { backStackEntry ->
+            val viewModel = sharedJournalSettingsViewModel(navController, backStackEntry)
+            JournalSettingsSleepQualityOptionRegisterScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
             )

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -3,16 +3,32 @@ package io.github.faening.lello.feature.journal.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.faening.lello.core.domain.usecase.options.AppetiteOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.ClimateOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.DosageFormOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.EmotionOptionUseCase
-import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
-import io.github.faening.lello.core.domain.usecase.options.SocialOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.FoodOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.HealthOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.MealOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.PortionOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SensationOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SleepActivityOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SleepQualityOptionUseCase
+import io.github.faening.lello.core.domain.usecase.options.SocialOptionUseCase
+import io.github.faening.lello.core.model.journal.AppetiteOption
 import io.github.faening.lello.core.model.journal.ClimateOption
+import io.github.faening.lello.core.model.journal.DosageFormOption
 import io.github.faening.lello.core.model.journal.EmotionOption
-import io.github.faening.lello.core.model.journal.LocationOption
-import io.github.faening.lello.core.model.journal.SocialOption
+import io.github.faening.lello.core.model.journal.FoodOption
 import io.github.faening.lello.core.model.journal.HealthOption
+import io.github.faening.lello.core.model.journal.LocationOption
+import io.github.faening.lello.core.model.journal.MealOption
+import io.github.faening.lello.core.model.journal.PortionOption
+import io.github.faening.lello.core.model.journal.SensationOption
+import io.github.faening.lello.core.model.journal.SleepActivityOption
+import io.github.faening.lello.core.model.journal.SleepQualityOption
+import io.github.faening.lello.core.model.journal.SocialOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -25,6 +41,14 @@ class JournalSettingsViewModel @Inject constructor(
     locationOptionUseCase: LocationOptionUseCase,
     socialOptionUseCase: SocialOptionUseCase,
     healthOptionUseCase: HealthOptionUseCase,
+    appetiteOptionUseCase: AppetiteOptionUseCase,
+    dosageFormOptionUseCase: DosageFormOptionUseCase,
+    foodOptionUseCase: FoodOptionUseCase,
+    mealOptionUseCase: MealOptionUseCase,
+    portionOptionUseCase: PortionOptionUseCase,
+    sensationOptionUseCase: SensationOptionUseCase,
+    sleepActivityOptionUseCase: SleepActivityOptionUseCase,
+    sleepQualityOptionUseCase: SleepQualityOptionUseCase,
 ) : ViewModel() {
 
     private val _emotionOptions = MutableStateFlow<List<EmotionOption>>(emptyList())
@@ -42,6 +66,30 @@ class JournalSettingsViewModel @Inject constructor(
     private val _healthOptions = MutableStateFlow<List<HealthOption>>(emptyList())
     val healthOptions: StateFlow<List<HealthOption>> = _healthOptions
 
+    private val _appetiteOptions = MutableStateFlow<List<AppetiteOption>>(emptyList())
+    val appetiteOptions: StateFlow<List<AppetiteOption>> = _appetiteOptions
+
+    private val _dosageFormOptions = MutableStateFlow<List<DosageFormOption>>(emptyList())
+    val dosageFormOptions: StateFlow<List<DosageFormOption>> = _dosageFormOptions
+
+    private val _foodOptions = MutableStateFlow<List<FoodOption>>(emptyList())
+    val foodOptions: StateFlow<List<FoodOption>> = _foodOptions
+
+    private val _mealOptions = MutableStateFlow<List<MealOption>>(emptyList())
+    val mealOptions: StateFlow<List<MealOption>> = _mealOptions
+
+    private val _portionOptions = MutableStateFlow<List<PortionOption>>(emptyList())
+    val portionOptions: StateFlow<List<PortionOption>> = _portionOptions
+
+    private val _sensationOptions = MutableStateFlow<List<SensationOption>>(emptyList())
+    val sensationOptions: StateFlow<List<SensationOption>> = _sensationOptions
+
+    private val _sleepActivityOptions = MutableStateFlow<List<SleepActivityOption>>(emptyList())
+    val sleepActivityOptions: StateFlow<List<SleepActivityOption>> = _sleepActivityOptions
+
+    private val _sleepQualityOptions = MutableStateFlow<List<SleepQualityOption>>(emptyList())
+    val sleepQualityOptions: StateFlow<List<SleepQualityOption>> = _sleepQualityOptions
+
     init {
         viewModelScope.launch {
             emotionOptionUseCase.getAll().collect { _emotionOptions.value = it }
@@ -57,6 +105,30 @@ class JournalSettingsViewModel @Inject constructor(
         }
         viewModelScope.launch {
             healthOptionUseCase.getAll().collect { _healthOptions.value = it }
+        }
+        viewModelScope.launch {
+            appetiteOptionUseCase.getAll().collect { _appetiteOptions.value = it }
+        }
+        viewModelScope.launch {
+            dosageFormOptionUseCase.getAll().collect { _dosageFormOptions.value = it }
+        }
+        viewModelScope.launch {
+            foodOptionUseCase.getAll().collect { _foodOptions.value = it }
+        }
+        viewModelScope.launch {
+            mealOptionUseCase.getAll().collect { _mealOptions.value = it }
+        }
+        viewModelScope.launch {
+            portionOptionUseCase.getAll().collect { _portionOptions.value = it }
+        }
+        viewModelScope.launch {
+            sensationOptionUseCase.getAll().collect { _sensationOptions.value = it }
+        }
+        viewModelScope.launch {
+            sleepActivityOptionUseCase.getAll().collect { _sleepActivityOptions.value = it }
+        }
+        viewModelScope.launch {
+            sleepQualityOptionUseCase.getAll().collect { _sleepQualityOptions.value = it }
         }
     }
 
@@ -86,6 +158,54 @@ class JournalSettingsViewModel @Inject constructor(
 
     fun toggleHealthOption(option: HealthOption, active: Boolean) {
         _healthOptions.value = _healthOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleAppetiteOption(option: AppetiteOption, active: Boolean) {
+        _appetiteOptions.value = _appetiteOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleDosageFormOption(option: DosageFormOption, active: Boolean) {
+        _dosageFormOptions.value = _dosageFormOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleFoodOption(option: FoodOption, active: Boolean) {
+        _foodOptions.value = _foodOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleMealOption(option: MealOption, active: Boolean) {
+        _mealOptions.value = _mealOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun togglePortionOption(option: PortionOption, active: Boolean) {
+        _portionOptions.value = _portionOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleSensationOption(option: SensationOption, active: Boolean) {
+        _sensationOptions.value = _sensationOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleSleepActivityOption(option: SleepActivityOption, active: Boolean) {
+        _sleepActivityOptions.value = _sleepActivityOptions.value.map {
+            if (it.id == option.id) it.copy(active = active) else it
+        }
+    }
+
+    fun toggleSleepQualityOption(option: SleepQualityOption, active: Boolean) {
+        _sleepQualityOptions.value = _sleepQualityOptions.value.map {
             if (it.id == option.id) it.copy(active = active) else it
         }
     }

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/appetite/JournalSettingsAppetiteOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/appetite/JournalSettingsAppetiteOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.appetite
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsAppetiteOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/appetite/JournalSettingsAppetiteOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/appetite/JournalSettingsAppetiteOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.appetite
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.AppetiteOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsAppetiteOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.appetiteOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsAppetiteOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleAppetiteOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsAppetiteOptionContainer(
+    options: List<AppetiteOption>,
+    onToggle: (AppetiteOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsAppetiteOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsAppetiteOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsAppetiteOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsAppetiteOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_appetite_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsAppetiteOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_appetite_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsAppetiteOptionContent(
+    options: List<AppetiteOption>,
+    onToggle: (AppetiteOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as AppetiteOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsAppetiteOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsAppetiteOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/dosageform/JournalSettingsDosageFormOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/dosageform/JournalSettingsDosageFormOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.dosageform
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsDosageFormOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/dosageform/JournalSettingsDosageFormOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/dosageform/JournalSettingsDosageFormOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.dosageform
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.DosageFormOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsDosageFormOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.dosageFormOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsDosageFormOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleDosageFormOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsDosageFormOptionContainer(
+    options: List<DosageFormOption>,
+    onToggle: (DosageFormOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsDosageFormOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsDosageFormOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsDosageFormOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsDosageFormOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_dosageform_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsDosageFormOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_dosageform_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsDosageFormOptionContent(
+    options: List<DosageFormOption>,
+    onToggle: (DosageFormOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as DosageFormOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsDosageFormOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsDosageFormOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/food/JournalSettingsFoodOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/food/JournalSettingsFoodOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.food
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsFoodOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/food/JournalSettingsFoodOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/food/JournalSettingsFoodOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.food
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.FoodOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsFoodOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.foodOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsFoodOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleFoodOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsFoodOptionContainer(
+    options: List<FoodOption>,
+    onToggle: (FoodOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsFoodOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsFoodOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsFoodOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsFoodOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_food_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsFoodOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_food_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsFoodOptionContent(
+    options: List<FoodOption>,
+    onToggle: (FoodOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as FoodOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsFoodOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsFoodOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/meal/JournalSettingsMealOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/meal/JournalSettingsMealOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.meal
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsMealOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/meal/JournalSettingsMealOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/meal/JournalSettingsMealOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.meal
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.MealOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsMealOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.mealOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsMealOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleMealOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsMealOptionContainer(
+    options: List<MealOption>,
+    onToggle: (MealOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsMealOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsMealOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsMealOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsMealOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_meal_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsMealOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_meal_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsMealOptionContent(
+    options: List<MealOption>,
+    onToggle: (MealOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as MealOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsMealOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsMealOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/portion/JournalSettingsPortionOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/portion/JournalSettingsPortionOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.portion
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsPortionOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/portion/JournalSettingsPortionOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/portion/JournalSettingsPortionOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.portion
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.PortionOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsPortionOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.portionOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsPortionOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.togglePortionOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsPortionOptionContainer(
+    options: List<PortionOption>,
+    onToggle: (PortionOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsPortionOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsPortionOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsPortionOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsPortionOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_portion_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsPortionOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_portion_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsPortionOptionContent(
+    options: List<PortionOption>,
+    onToggle: (PortionOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as PortionOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsPortionOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsPortionOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sensation/JournalSettingsSensationOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sensation/JournalSettingsSensationOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.sensation
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsSensationOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sensation/JournalSettingsSensationOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sensation/JournalSettingsSensationOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.sensation
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.SensationOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsSensationOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.sensationOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsSensationOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleSensationOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSensationOptionContainer(
+    options: List<SensationOption>,
+    onToggle: (SensationOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsSensationOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsSensationOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsSensationOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSensationOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_sensation_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsSensationOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_sensation_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSensationOptionContent(
+    options: List<SensationOption>,
+    onToggle: (SensationOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as SensationOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsSensationOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsSensationOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepactivity/JournalSettingsSleepActivityOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepactivity/JournalSettingsSleepActivityOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.sleepactivity
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsSleepActivityOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepactivity/JournalSettingsSleepActivityOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepactivity/JournalSettingsSleepActivityOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.sleepactivity
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.SleepActivityOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsSleepActivityOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.sleepActivityOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsSleepActivityOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleSleepActivityOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepActivityOptionContainer(
+    options: List<SleepActivityOption>,
+    onToggle: (SleepActivityOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsSleepActivityOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsSleepActivityOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsSleepActivityOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepActivityOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_sleepactivity_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsSleepActivityOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_sleepactivity_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepActivityOptionContent(
+    options: List<SleepActivityOption>,
+    onToggle: (SleepActivityOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as SleepActivityOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsSleepActivityOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsSleepActivityOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepquality/JournalSettingsSleepQualityOptionRegisterScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepquality/JournalSettingsSleepQualityOptionRegisterScreen.kt
@@ -1,0 +1,12 @@
+package io.github.faening.lello.feature.journal.settings.screen.sleepquality
+
+import androidx.compose.runtime.Composable
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+
+@Composable
+fun JournalSettingsSleepQualityOptionRegisterScreen(
+    viewModel: JournalSettingsViewModel,
+    onBack: () -> Unit
+) {
+
+}

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepquality/JournalSettingsSleepQualityOptionScreen.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/screen/sleepquality/JournalSettingsSleepQualityOptionScreen.kt
@@ -1,0 +1,137 @@
+package io.github.faening.lello.feature.journal.settings.screen.sleepquality
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.faening.lello.core.designsystem.component.LelloFilledButton
+import io.github.faening.lello.core.designsystem.component.LelloOptionList
+import io.github.faening.lello.core.designsystem.component.LelloTopAppBar
+import io.github.faening.lello.core.designsystem.component.TopAppBarAction
+import io.github.faening.lello.core.designsystem.component.TopAppBarTitle
+import io.github.faening.lello.core.designsystem.theme.Dimension
+import io.github.faening.lello.core.designsystem.theme.LelloColorScheme
+import io.github.faening.lello.core.designsystem.theme.LelloTheme
+import io.github.faening.lello.core.model.journal.SleepQualityOption
+import io.github.faening.lello.feature.journal.settings.JournalSettingsViewModel
+import io.github.faening.lello.feature.journal.settings.R as settingsR
+
+@Composable
+internal fun JournalSettingsSleepQualityOptionScreen(
+    viewModel: JournalSettingsViewModel,
+    colorScheme: LelloColorScheme,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    val options by viewModel.sleepQualityOptions.collectAsState()
+
+    LelloTheme(scheme = colorScheme) {
+        JournalSettingsSleepQualityOptionContainer(
+            options = options,
+            onToggle = { option, active -> viewModel.toggleSleepQualityOption(option, active) },
+            onBack = onBack,
+            onRegister = onRegister
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepQualityOptionContainer(
+    options: List<SleepQualityOption>,
+    onToggle: (SleepQualityOption, Boolean) -> Unit,
+    onBack: () -> Unit,
+    onRegister: () -> Unit
+) {
+    Scaffold(
+        topBar = { JournalSettingsSleepQualityOptionTopBar(onBack) },
+        bottomBar = { JournalSettingsSleepQualityOptionBottomBar(onRegister) }
+    ) { paddingValues ->
+        JournalSettingsSleepQualityOptionContent(
+            options = options,
+            onToggle = onToggle,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepQualityOptionTopBar(
+    onBack: () -> Unit
+) {
+    val title = settingsR.string.journal_settings_sleepquality_appbar_title
+    LelloTopAppBar(
+        title = TopAppBarTitle(title),
+        navigateUp = TopAppBarAction(onClick = onBack),
+    )
+}
+
+@Composable
+private fun JournalSettingsSleepQualityOptionBottomBar(
+    onRegister: () -> Unit
+) {
+    val label = stringResource(settingsR.string.journal_settings_sleepquality_register_button_label)
+    Row(
+        modifier = Modifier.padding(Dimension.Medium)
+    ) {
+        LelloFilledButton(
+            label = label,
+            onClick = onRegister,
+        )
+    }
+}
+
+@Composable
+private fun JournalSettingsSleepQualityOptionContent(
+    options: List<SleepQualityOption>,
+    onToggle: (SleepQualityOption, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(Dimension.Medium)
+    ) {
+        Text(
+            text = "Gerencie os itens disponíveis para preenchimento em seus diários",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.padding(bottom = Dimension.ExtraLarge)
+        )
+
+        LelloOptionList(
+            options = options,
+            onToggle = { option, active ->
+                onToggle(option as SleepQualityOption, active)
+            },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFFFFBF0,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+fun JournalSettingsSleepQualityOptionScreenPreview() {
+    LelloTheme {
+        JournalSettingsSleepQualityOptionContainer(
+            options = listOf(),
+            onToggle = { _, _ -> },
+            onBack = {},
+            onRegister = {}
+        )
+    }
+}

--- a/feature/journal/settings/src/main/res/values/strings.xml
+++ b/feature/journal/settings/src/main/res/values/strings.xml
@@ -22,4 +22,36 @@
     <string name="journal_settings_health_appbar_title">Saúde</string>
     <string name="journal_settings_health_register_button_label">Cadastrar item de saúde</string>
 
+    <!-- Appetite -->
+    <string name="journal_settings_appetite_appbar_title">Apetites</string>
+    <string name="journal_settings_appetite_register_button_label">Cadastrar apetite</string>
+
+    <!-- Dosage Form -->
+    <string name="journal_settings_dosageform_appbar_title">Formas de Dosagem</string>
+    <string name="journal_settings_dosageform_register_button_label">Cadastrar forma de dosagem</string>
+
+    <!-- Food -->
+    <string name="journal_settings_food_appbar_title">Alimentos</string>
+    <string name="journal_settings_food_register_button_label">Cadastrar alimento</string>
+
+    <!-- Meal -->
+    <string name="journal_settings_meal_appbar_title">Refeições</string>
+    <string name="journal_settings_meal_register_button_label">Cadastrar refeição</string>
+
+    <!-- Portion -->
+    <string name="journal_settings_portion_appbar_title">Porções</string>
+    <string name="journal_settings_portion_register_button_label">Cadastrar porção</string>
+
+    <!-- Sensation -->
+    <string name="journal_settings_sensation_appbar_title">Sensações</string>
+    <string name="journal_settings_sensation_register_button_label">Cadastrar sensação</string>
+
+    <!-- Sleep Activity -->
+    <string name="journal_settings_sleepactivity_appbar_title">Atividades de Sono</string>
+    <string name="journal_settings_sleepactivity_register_button_label">Cadastrar atividade de sono</string>
+
+    <!-- Sleep Quality -->
+    <string name="journal_settings_sleepquality_appbar_title">Qualidade do Sono</string>
+    <string name="journal_settings_sleepquality_register_button_label">Cadastrar qualidade do sono</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- support new journal option types in `JournalSettingsViewModel`
- wire new routes in `JournalSettingsNavigation`
- add option management screens for appetite, dosage form, food, meal, portion, sensation, sleep activity and sleep quality
- include related strings

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_684b0724f49c832c838d575232c4d94e