### PR TITLE
LEL-015 feat(feature/settings) add toggle for journal options

### DIFF
--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/AppetiteOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/AppetiteOptionUseCase.kt
@@ -45,6 +45,16 @@ class AppetiteOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active status for the provided options.
+     */
+    suspend fun updateActiveStatus(vararg items: AppetiteOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: AppetiteOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/ClimateOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/ClimateOptionUseCase.kt
@@ -45,6 +45,17 @@ class ClimateOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Updates only the `active` property of the received options after
+     * validating their ids.
+     */
+    suspend fun updateActiveStatus(vararg items: ClimateOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: ClimateOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/DosageFormOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/DosageFormOptionUseCase.kt
@@ -45,6 +45,16 @@ class DosageFormOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Persist only the new active status of the given options.
+     */
+    suspend fun updateActiveStatus(vararg items: DosageFormOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: DosageFormOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/EmotionOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/EmotionOptionUseCase.kt
@@ -45,6 +45,17 @@ class EmotionOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Updates only the `active` status of the given options. It just checks if
+     * the ids are valid and persists the received items.
+     */
+    suspend fun updateActiveStatus(vararg items: EmotionOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: EmotionOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/FoodOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/FoodOptionUseCase.kt
@@ -45,6 +45,16 @@ class FoodOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active state of provided options.
+     */
+    suspend fun updateActiveStatus(vararg items: FoodOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: FoodOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/HealthOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/HealthOptionUseCase.kt
@@ -45,6 +45,16 @@ class HealthOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Only updates the `active` status of the given options.
+     */
+    suspend fun updateActiveStatus(vararg items: HealthOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: HealthOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/LocationOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/LocationOptionUseCase.kt
@@ -45,6 +45,16 @@ class LocationOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update the active status of the given location options.
+     */
+    suspend fun updateActiveStatus(vararg items: LocationOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: LocationOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/MealOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/MealOptionUseCase.kt
@@ -45,6 +45,16 @@ class MealOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active property of the provided meal options.
+     */
+    suspend fun updateActiveStatus(vararg items: MealOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: MealOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/PortionOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/PortionOptionUseCase.kt
@@ -45,6 +45,16 @@ class PortionOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Updates only the active state of the portion options.
+     */
+    suspend fun updateActiveStatus(vararg items: PortionOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: PortionOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SensationOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SensationOptionUseCase.kt
@@ -45,6 +45,16 @@ class SensationOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active flag of provided sensation options.
+     */
+    suspend fun updateActiveStatus(vararg items: SensationOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: SensationOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepActivityOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepActivityOptionUseCase.kt
@@ -45,6 +45,16 @@ class SleepActivityOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active state of the sleep activity options.
+     */
+    suspend fun updateActiveStatus(vararg items: SleepActivityOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: SleepActivityOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepQualityOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SleepQualityOptionUseCase.kt
@@ -45,6 +45,16 @@ class SleepQualityOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Updates only the active status for the given sleep quality options.
+     */
+    suspend fun updateActiveStatus(vararg items: SleepQualityOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: SleepQualityOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SocialOptionUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/options/SocialOptionUseCase.kt
@@ -45,6 +45,16 @@ class SocialOptionUseCase @Inject constructor(
         formattedItems.forEach { item -> repository.update(item) }
     }
 
+    /**
+     * Update only the active flag for the provided social options.
+     */
+    suspend fun updateActiveStatus(vararg items: SocialOption) {
+        items.forEach { item ->
+            item.id.validateId()
+        }
+        items.forEach { item -> repository.update(item) }
+    }
+
     suspend fun delete(vararg items: SocialOption) {
         items.forEach { item ->
             item.blocked.validateNotBlocked()

--- a/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
+++ b/feature/journal/settings/src/main/java/io/github/faening/lello/feature/journal/settings/JournalSettingsViewModel.kt
@@ -229,20 +229,61 @@ class JournalSettingsViewModel @Inject constructor(
     }
 
     fun toggleOption(type: JournalOptionType, option: JournalOption, active: Boolean) {
-        when (type) {
-            JournalOptionType.EMOTION -> toggleEmotionOption(option as EmotionOption, active)
-            JournalOptionType.CLIMATE -> toggleClimateOption(option as ClimateOption, active)
-            JournalOptionType.LOCATION -> toggleLocationOption(option as LocationOption, active)
-            JournalOptionType.SOCIAL -> toggleSocialOption(option as SocialOption, active)
-            JournalOptionType.HEALTH -> toggleHealthOption(option as HealthOption, active)
-            JournalOptionType.APPETITE -> toggleAppetiteOption(option as AppetiteOption, active)
-            JournalOptionType.DOSAGE_FORM -> toggleDosageFormOption(option as DosageFormOption, active)
-            JournalOptionType.FOOD -> toggleFoodOption(option as FoodOption, active)
-            JournalOptionType.MEAL -> toggleMealOption(option as MealOption, active)
-            JournalOptionType.PORTION -> togglePortionOption(option as PortionOption, active)
-            JournalOptionType.SENSATION -> toggleSensationOption(option as SensationOption, active)
-            JournalOptionType.SLEEP_ACTIVITY -> toggleSleepActivityOption(option as SleepActivityOption, active)
-            JournalOptionType.SLEEP_QUALITY -> toggleSleepQualityOption(option as SleepQualityOption, active)
+        viewModelScope.launch {
+            when (type) {
+                JournalOptionType.EMOTION -> {
+                    emotionOptionUseCase.updateActiveStatus((option as EmotionOption).copy(active = active))
+                    toggleEmotionOption(option, active)
+                }
+                JournalOptionType.CLIMATE -> {
+                    climateOptionUseCase.updateActiveStatus((option as ClimateOption).copy(active = active))
+                    toggleClimateOption(option, active)
+                }
+                JournalOptionType.LOCATION -> {
+                    locationOptionUseCase.updateActiveStatus((option as LocationOption).copy(active = active))
+                    toggleLocationOption(option, active)
+                }
+                JournalOptionType.SOCIAL -> {
+                    socialOptionUseCase.updateActiveStatus((option as SocialOption).copy(active = active))
+                    toggleSocialOption(option, active)
+                }
+                JournalOptionType.HEALTH -> {
+                    healthOptionUseCase.updateActiveStatus((option as HealthOption).copy(active = active))
+                    toggleHealthOption(option, active)
+                }
+                JournalOptionType.APPETITE -> {
+                    appetiteOptionUseCase.updateActiveStatus((option as AppetiteOption).copy(active = active))
+                    toggleAppetiteOption(option, active)
+                }
+                JournalOptionType.DOSAGE_FORM -> {
+                    dosageFormOptionUseCase.updateActiveStatus((option as DosageFormOption).copy(active = active))
+                    toggleDosageFormOption(option, active)
+                }
+                JournalOptionType.FOOD -> {
+                    foodOptionUseCase.updateActiveStatus((option as FoodOption).copy(active = active))
+                    toggleFoodOption(option, active)
+                }
+                JournalOptionType.MEAL -> {
+                    mealOptionUseCase.updateActiveStatus((option as MealOption).copy(active = active))
+                    toggleMealOption(option, active)
+                }
+                JournalOptionType.PORTION -> {
+                    portionOptionUseCase.updateActiveStatus((option as PortionOption).copy(active = active))
+                    togglePortionOption(option, active)
+                }
+                JournalOptionType.SENSATION -> {
+                    sensationOptionUseCase.updateActiveStatus((option as SensationOption).copy(active = active))
+                    toggleSensationOption(option, active)
+                }
+                JournalOptionType.SLEEP_ACTIVITY -> {
+                    sleepActivityOptionUseCase.updateActiveStatus((option as SleepActivityOption).copy(active = active))
+                    toggleSleepActivityOption(option, active)
+                }
+                JournalOptionType.SLEEP_QUALITY -> {
+                    sleepQualityOptionUseCase.updateActiveStatus((option as SleepQualityOption).copy(active = active))
+                    toggleSleepQualityOption(option, active)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow each journal option use case to update active status
- persist option toggling in `JournalSettingsViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not connect to Kotlin compile daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684c7ac3b720832c85718314d3976ddb