### PR TITLE
LEL-016 feat(core/database): add sleep journal persistence

### DIFF
--- a/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
@@ -14,6 +14,7 @@ import io.github.faening.lello.core.data.repository.JournalCategoryRepository
 import io.github.faening.lello.core.data.repository.LocationOptionRepository
 import io.github.faening.lello.core.data.repository.MealOptionRepository
 import io.github.faening.lello.core.data.repository.MoodJournalRepository
+import io.github.faening.lello.core.data.repository.SleepJournalRepository
 import io.github.faening.lello.core.data.repository.PortionOptionRepository
 import io.github.faening.lello.core.data.repository.SleepSensationOptionRepository
 import io.github.faening.lello.core.data.repository.SleepActivityOptionRepository
@@ -29,6 +30,7 @@ import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
 import io.github.faening.lello.core.database.dao.MealOptionDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
+import io.github.faening.lello.core.database.dao.SleepJournalDao
 import io.github.faening.lello.core.database.dao.PortionOptionDao
 import io.github.faening.lello.core.database.dao.SleepSensationOptionDao
 import io.github.faening.lello.core.database.dao.SleepActivityOptionDao
@@ -47,6 +49,7 @@ import io.github.faening.lello.core.model.journal.JournalCategory
 import io.github.faening.lello.core.model.journal.LocationOption
 import io.github.faening.lello.core.model.journal.MealOption
 import io.github.faening.lello.core.model.journal.MoodJournal
+import io.github.faening.lello.core.model.journal.SleepJournal
 import io.github.faening.lello.core.model.journal.PortionOption
 import io.github.faening.lello.core.model.journal.SleepSensationOption
 import io.github.faening.lello.core.model.journal.SleepActivityOption
@@ -78,6 +81,13 @@ object RepositoryModule {
         dao: MoodJournalDao
     ): JournalResources<MoodJournal> {
         return MoodJournalRepository(dao)
+    }
+
+    @Provides
+    fun provideSleepJournalRepository(
+        dao: SleepJournalDao
+    ): JournalResources<SleepJournal> {
+        return SleepJournalRepository(dao)
     }
 
     @Provides

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepJournalRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/SleepJournalRepository.kt
@@ -1,0 +1,68 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.SleepJournalDao
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntity
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntityLocationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepActivityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepQualityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepSensationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.toEntity
+import io.github.faening.lello.core.database.model.journal.sleep.toModel
+import io.github.faening.lello.core.domain.repository.JournalResources
+import io.github.faening.lello.core.model.journal.SleepJournal
+import javax.inject.Inject
+
+class SleepJournalRepository @Inject constructor(
+    private val dao: SleepJournalDao
+) : JournalResources<SleepJournal> {
+
+    override suspend fun insert(entry: SleepJournal): Long {
+        val sleepJournalId = dao.insert(entry.toEntity())
+
+        if (entry.sleepSensationOptions.isNotEmpty()) {
+            dao.insertSleepSensationRefs(
+                entry.sleepSensationOptions.map {
+                    SleepJournalEntitySleepSensationOptionEntityCrossRef(sleepJournalId, it.id)
+                }
+            )
+        }
+
+        if (entry.sleepQualityOptions.isNotEmpty()) {
+            dao.insertSleepQualityRefs(
+                entry.sleepQualityOptions.map {
+                    SleepJournalEntitySleepQualityOptionEntityCrossRef(sleepJournalId, it.id)
+                }
+            )
+        }
+
+        if (entry.sleepActivityOptions.isNotEmpty()) {
+            dao.insertSleepActivityRefs(
+                entry.sleepActivityOptions.map {
+                    SleepJournalEntitySleepActivityOptionEntityCrossRef(sleepJournalId, it.id)
+                }
+            )
+        }
+
+        if (entry.locationOptions.isNotEmpty()) {
+            dao.insertLocationRefs(
+                entry.locationOptions.map {
+                    SleepJournalEntityLocationOptionEntityCrossRef(sleepJournalId, it.id)
+                }
+            )
+        }
+
+        return sleepJournalId
+    }
+
+    override suspend fun getAll(): List<SleepJournal> {
+        return dao.getAll().map { it.toModel() }
+    }
+
+    override suspend fun getById(id: Long): SleepJournal? {
+        return dao.getByIdWithOptions(id)?.toModel()
+    }
+
+    override suspend fun delete(id: SleepJournal) {
+        dao.delete(id.toEntity())
+    }
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -14,6 +14,7 @@ import io.github.faening.lello.core.database.dao.LocationOptionDao
 import io.github.faening.lello.core.database.dao.MealOptionDao
 import io.github.faening.lello.core.database.dao.PortionOptionDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
+import io.github.faening.lello.core.database.dao.SleepJournalDao
 import io.github.faening.lello.core.database.dao.SleepSensationOptionDao
 import io.github.faening.lello.core.database.dao.SleepQualityOptionDao
 import io.github.faening.lello.core.database.dao.SocialOptionDao
@@ -34,6 +35,11 @@ import io.github.faening.lello.core.database.model.journal.mood.MoodJournalEntit
 import io.github.faening.lello.core.database.model.journal.mood.MoodJournalEntityHealthOptionEntityCrossRef
 import io.github.faening.lello.core.database.model.journal.mood.MoodJournalEntityLocationOptionEntityCrossRef
 import io.github.faening.lello.core.database.model.journal.mood.MoodJournalEntitySocialOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntity
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepSensationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepQualityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepActivityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntityLocationOptionEntityCrossRef
 import io.github.faening.lello.core.database.model.option.SleepSensationOptionEntity
 import io.github.faening.lello.core.database.model.option.SleepQualityOptionEntity
 import io.github.faening.lello.core.database.model.option.SocialOptionEntity
@@ -58,6 +64,11 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
         SleepQualityOptionEntity::class,
         SleepSensationOptionEntity::class,
         SocialOptionEntity::class,
+        SleepJournalEntity::class,
+        SleepJournalEntitySleepSensationOptionEntityCrossRef::class,
+        SleepJournalEntitySleepQualityOptionEntityCrossRef::class,
+        SleepJournalEntitySleepActivityOptionEntityCrossRef::class,
+        SleepJournalEntityLocationOptionEntityCrossRef::class,
         MoodJournalEntity::class,
         MoodJournalEntityEmotionOptionEntityCrossRef::class,
         MoodJournalEntityClimateOptionEntityCrossRef::class,
@@ -77,6 +88,7 @@ abstract class LelloDatabase : RoomDatabase() {
 
     // journals
     abstract fun moodJournalEntryDao(): MoodJournalDao
+    abstract fun sleepJournalDao(): SleepJournalDao
     abstract fun journalCategoryDao(): JournalCategoryDao
 
     // options

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/SleepJournalDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/SleepJournalDao.kt
@@ -1,0 +1,61 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntity
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntityLocationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepActivityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepQualityOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntitySleepSensationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.sleep.SleepJournalEntityWithOptions
+import io.github.faening.lello.core.domain.repository.JournalResources
+
+@Dao
+interface SleepJournalDao : JournalResources<SleepJournalEntity> {
+
+    @Transaction
+    @Query("SELECT * FROM sleep_journals ORDER BY date DESC")
+    override suspend fun getAll(): List<SleepJournalEntity>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM sleep_journals
+            WHERE sleepJournalId = :id
+            LIMIT 1
+        """
+    )
+    override suspend fun getById(id: Long): SleepJournalEntity?
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM sleep_journals
+            WHERE sleepJournalId = :id
+            LIMIT 1
+        """
+    )
+    suspend fun getByIdWithOptions(id: Long): SleepJournalEntityWithOptions?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun insert(entry: SleepJournalEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSleepSensationRefs(refs: List<SleepJournalEntitySleepSensationOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSleepQualityRefs(refs: List<SleepJournalEntitySleepQualityOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSleepActivityRefs(refs: List<SleepJournalEntitySleepActivityOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLocationRefs(refs: List<SleepJournalEntityLocationOptionEntityCrossRef>)
+
+    @Delete
+    override suspend fun delete(id: SleepJournalEntity)
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -18,6 +18,11 @@ internal object DaoModule {
     ) = database.moodJournalEntryDao()
 
     @Provides
+    fun provideSleepJournalDao(
+        database: LelloDatabase,
+    ) = database.sleepJournalDao()
+
+    @Provides
     fun provideJournalCategoryDao(
         database: LelloDatabase,
     ) = database.journalCategoryDao()

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntityLocationOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntityLocationOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.sleep
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "sleep_journals_location_options_cross_ref",
+    primaryKeys = ["sleepJournalId", "locationOptionId"],
+    indices = [Index(value = ["locationOptionId"])]
+)
+data class SleepJournalEntityLocationOptionEntityCrossRef(
+    val sleepJournalId: Long,
+    val locationOptionId: Long
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepActivityOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepActivityOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.sleep
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "sleep_journals_sleep_activity_options_cross_ref",
+    primaryKeys = ["sleepJournalId", "sleepActivityOptionId"],
+    indices = [Index(value = ["sleepActivityOptionId"])]
+)
+data class SleepJournalEntitySleepActivityOptionEntityCrossRef(
+    val sleepJournalId: Long,
+    val sleepActivityOptionId: Long
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepQualityOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepQualityOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.sleep
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "sleep_journals_sleep_quality_options_cross_ref",
+    primaryKeys = ["sleepJournalId", "sleepQualityOptionId"],
+    indices = [Index(value = ["sleepQualityOptionId"])]
+)
+data class SleepJournalEntitySleepQualityOptionEntityCrossRef(
+    val sleepJournalId: Long,
+    val sleepQualityOptionId: Long
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepSensationOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntitySleepSensationOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.sleep
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "sleep_journals_sleep_sensation_options_cross_ref",
+    primaryKeys = ["sleepJournalId", "sleepSensationOptionId"],
+    indices = [Index(value = ["sleepSensationOptionId"])]
+)
+data class SleepJournalEntitySleepSensationOptionEntityCrossRef(
+    val sleepJournalId: Long,
+    val sleepSensationOptionId: Long
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntityWithOptions.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/sleep/SleepJournalEntityWithOptions.kt
@@ -1,0 +1,65 @@
+package io.github.faening.lello.core.database.model.journal.sleep
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+import io.github.faening.lello.core.database.model.option.LocationOptionEntity
+import io.github.faening.lello.core.database.model.option.SleepActivityOptionEntity
+import io.github.faening.lello.core.database.model.option.SleepQualityOptionEntity
+import io.github.faening.lello.core.database.model.option.SleepSensationOptionEntity
+import io.github.faening.lello.core.model.journal.SleepJournal
+
+data class SleepJournalEntityWithOptions(
+    @Embedded val entry: SleepJournalEntity,
+    @Relation(
+        parentColumn = "sleepJournalId",
+        entityColumn = "sleepSensationOptionId",
+        associateBy = Junction(
+            value = SleepJournalEntitySleepSensationOptionEntityCrossRef::class,
+            parentColumn = "sleepJournalId",
+            entityColumn = "sleepSensationOptionId"
+        )
+    )
+    val sleepSensationOptions: List<SleepSensationOptionEntity>,
+    @Relation(
+        parentColumn = "sleepJournalId",
+        entityColumn = "sleepQualityOptionId",
+        associateBy = Junction(
+            value = SleepJournalEntitySleepQualityOptionEntityCrossRef::class,
+            parentColumn = "sleepJournalId",
+            entityColumn = "sleepQualityOptionId"
+        )
+    )
+    val sleepQualityOptions: List<SleepQualityOptionEntity>,
+    @Relation(
+        parentColumn = "sleepJournalId",
+        entityColumn = "sleepActivityOptionId",
+        associateBy = Junction(
+            value = SleepJournalEntitySleepActivityOptionEntityCrossRef::class,
+            parentColumn = "sleepJournalId",
+            entityColumn = "sleepActivityOptionId"
+        )
+    )
+    val sleepActivityOptions: List<SleepActivityOptionEntity>,
+    @Relation(
+        parentColumn = "sleepJournalId",
+        entityColumn = "locationOptionId",
+        associateBy = Junction(
+            value = SleepJournalEntityLocationOptionEntityCrossRef::class,
+            parentColumn = "sleepJournalId",
+            entityColumn = "locationOptionId"
+        )
+    )
+    val locationOptions: List<LocationOptionEntity>
+)
+
+fun SleepJournalEntityWithOptions.toModel() = SleepJournal(
+    id = entry.sleepJournalId,
+    date = entry.date,
+    duration = entry.duration,
+    sleeplessTime = entry.sleeplessTime,
+    sleepSensationOptions = sleepSensationOptions.map { it.toModel() },
+    sleepQualityOptions = sleepQualityOptions.map { it.toModel() },
+    sleepActivityOptions = sleepActivityOptions.map { it.toModel() },
+    locationOptions = locationOptions.map { it.toModel() }
+)

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/journal/SleepJournalUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/journal/SleepJournalUseCase.kt
@@ -1,0 +1,25 @@
+package io.github.faening.lello.core.domain.usecase.journal
+
+import io.github.faening.lello.core.domain.repository.JournalResources
+import io.github.faening.lello.core.model.journal.SleepJournal
+import javax.inject.Inject
+
+class SleepJournalUseCase @Inject constructor(
+    private val repository: JournalResources<SleepJournal>
+) {
+    suspend fun getAll(): List<SleepJournal> {
+        return repository.getAll()
+    }
+
+    suspend fun getById(id: Long): SleepJournal? {
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg entries: SleepJournal) {
+        entries.forEach { repository.insert(it) }
+    }
+
+    suspend fun delete(vararg entries: SleepJournal) {
+        entries.forEach { repository.delete(it) }
+    }
+}

--- a/feature/journal/sleep/src/main/java/io/github/faening/lello/feature/journal/sleep/SleepJournalViewModel.kt
+++ b/feature/journal/sleep/src/main/java/io/github/faening/lello/feature/journal/sleep/SleepJournalViewModel.kt
@@ -3,6 +3,7 @@ package io.github.faening.lello.feature.journal.sleep
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.faening.lello.core.domain.usecase.journal.SleepJournalUseCase
 import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.SleepActivityOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.SleepQualityOptionUseCase
@@ -25,6 +26,7 @@ class SleepJournalViewModel @Inject constructor(
     sleepQualityOptionUseCase: SleepQualityOptionUseCase,
     sleepAcitivityOptionUseCase: SleepActivityOptionUseCase,
     locationOptionUseCase: LocationOptionUseCase,
+    private val sleepJournalUseCase: SleepJournalUseCase,
 ) : ViewModel() {
 
     private val _sleepDuration = MutableStateFlow("")
@@ -130,10 +132,10 @@ class SleepJournalViewModel @Inject constructor(
     }
 
     fun saveSleepJournal() {
-        if (_sleepJournal != null) return
+        if (_sleepJournal.value != null) return
         viewModelScope.launch {
             val journal = buildSleepJournal()
-            // Add sleepJournalUseCase.save(journal)
+            sleepJournalUseCase.save(journal)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add SleepJournal cross-ref tables
- add SleepJournal DAO and repository
- wire SleepJournal DAO in database and DI modules
- create domain SleepJournalUseCase
- save the sleep journal via viewmodel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce310e658832c9456d25d97584b90