### PR TITLE
LEL-017 feat(core/database)? add `MealJournal` database support

### DIFF
--- a/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/di/RepositoryModule.kt
@@ -13,6 +13,7 @@ import io.github.faening.lello.core.data.repository.HealthOptionRepository
 import io.github.faening.lello.core.data.repository.JournalCategoryRepository
 import io.github.faening.lello.core.data.repository.LocationOptionRepository
 import io.github.faening.lello.core.data.repository.MealOptionRepository
+import io.github.faening.lello.core.data.repository.MealJournalRepository
 import io.github.faening.lello.core.data.repository.MoodJournalRepository
 import io.github.faening.lello.core.data.repository.SleepJournalRepository
 import io.github.faening.lello.core.data.repository.PortionOptionRepository
@@ -29,6 +30,7 @@ import io.github.faening.lello.core.database.dao.HealthOptionDao
 import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
 import io.github.faening.lello.core.database.dao.MealOptionDao
+import io.github.faening.lello.core.database.dao.MealJournalDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
 import io.github.faening.lello.core.database.dao.SleepJournalDao
 import io.github.faening.lello.core.database.dao.PortionOptionDao
@@ -48,6 +50,7 @@ import io.github.faening.lello.core.model.option.HealthOption
 import io.github.faening.lello.core.model.journal.JournalCategory
 import io.github.faening.lello.core.model.option.LocationOption
 import io.github.faening.lello.core.model.option.MealOption
+import io.github.faening.lello.core.model.journal.MealJournal
 import io.github.faening.lello.core.model.journal.MoodJournal
 import io.github.faening.lello.core.model.journal.SleepJournal
 import io.github.faening.lello.core.model.option.PortionOption
@@ -81,6 +84,13 @@ object RepositoryModule {
         dao: MoodJournalDao
     ): JournalResources<MoodJournal> {
         return MoodJournalRepository(dao)
+    }
+
+    @Provides
+    fun provideMealJournalRepository(
+        dao: MealJournalDao
+    ): JournalResources<MealJournal> {
+        return MealJournalRepository(dao)
     }
 
     @Provides

--- a/core/data/src/main/java/io/github/faening/lello/core/data/repository/MealJournalRepository.kt
+++ b/core/data/src/main/java/io/github/faening/lello/core/data/repository/MealJournalRepository.kt
@@ -1,0 +1,86 @@
+package io.github.faening.lello.core.data.repository
+
+import io.github.faening.lello.core.database.dao.MealJournalDao
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntity
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityAppetiteOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityFoodOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityLocationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityMealOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityPortionOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntitySocialOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.toEntity
+import io.github.faening.lello.core.database.model.journal.meal.toModel
+import io.github.faening.lello.core.domain.repository.JournalResources
+import io.github.faening.lello.core.model.journal.MealJournal
+import javax.inject.Inject
+
+class MealJournalRepository @Inject constructor(
+    private val dao: MealJournalDao
+) : JournalResources<MealJournal> {
+
+    override suspend fun insert(entry: MealJournal): Long {
+        val mealJournalId = dao.insert(entry.toEntity())
+
+        if (entry.mealOptions.isNotEmpty()) {
+            dao.insertMealRefs(
+                entry.mealOptions.map { option ->
+                    MealJournalEntityMealOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        if (entry.appetiteOptions.isNotEmpty()) {
+            dao.insertAppetiteRefs(
+                entry.appetiteOptions.map { option ->
+                    MealJournalEntityAppetiteOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        if (entry.foodOptions.isNotEmpty()) {
+            dao.insertFoodRefs(
+                entry.foodOptions.map { option ->
+                    MealJournalEntityFoodOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        if (entry.portionOptions.isNotEmpty()) {
+            dao.insertPortionRefs(
+                entry.portionOptions.map { option ->
+                    MealJournalEntityPortionOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        if (entry.locationOptions.isNotEmpty()) {
+            dao.insertLocationRefs(
+                entry.locationOptions.map { option ->
+                    MealJournalEntityLocationOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        if (entry.socialOptions.isNotEmpty()) {
+            dao.insertSocialRefs(
+                entry.socialOptions.map { option ->
+                    MealJournalEntitySocialOptionEntityCrossRef(mealJournalId, option.id)
+                }
+            )
+        }
+
+        return mealJournalId
+    }
+
+    override suspend fun getAll(): List<MealJournal> {
+        return dao.getAll().map { it.toModel() }
+    }
+
+    override suspend fun getById(id: Long): MealJournal? {
+        return dao.getByIdWithOptions(id)?.toModel()
+    }
+
+    override suspend fun delete(id: MealJournal) {
+        dao.delete(id.toEntity())
+    }
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/LelloDatabase.kt
@@ -12,6 +12,7 @@ import io.github.faening.lello.core.database.dao.HealthOptionDao
 import io.github.faening.lello.core.database.dao.JournalCategoryDao
 import io.github.faening.lello.core.database.dao.LocationOptionDao
 import io.github.faening.lello.core.database.dao.MealOptionDao
+import io.github.faening.lello.core.database.dao.MealJournalDao
 import io.github.faening.lello.core.database.dao.PortionOptionDao
 import io.github.faening.lello.core.database.dao.MoodJournalDao
 import io.github.faening.lello.core.database.dao.SleepJournalDao
@@ -44,6 +45,13 @@ import io.github.faening.lello.core.database.model.option.SleepSensationOptionEn
 import io.github.faening.lello.core.database.model.option.SleepQualityOptionEntity
 import io.github.faening.lello.core.database.model.option.SocialOptionEntity
 import io.github.faening.lello.core.database.model.option.SleepActivityOptionEntity
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntity
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityMealOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityAppetiteOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityFoodOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityPortionOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityLocationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntitySocialOptionEntityCrossRef
 import io.github.faening.lello.core.database.util.DateConverter
 import io.github.faening.lello.core.database.util.InstantConverters
 import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
@@ -74,7 +82,14 @@ import io.github.faening.lello.core.database.util.JournalMoodTypeConverter
         MoodJournalEntityClimateOptionEntityCrossRef::class,
         MoodJournalEntityLocationOptionEntityCrossRef::class,
         MoodJournalEntitySocialOptionEntityCrossRef::class,
-        MoodJournalEntityHealthOptionEntityCrossRef::class
+        MoodJournalEntityHealthOptionEntityCrossRef::class,
+        MealJournalEntity::class,
+        MealJournalEntityMealOptionEntityCrossRef::class,
+        MealJournalEntityAppetiteOptionEntityCrossRef::class,
+        MealJournalEntityFoodOptionEntityCrossRef::class,
+        MealJournalEntityPortionOptionEntityCrossRef::class,
+        MealJournalEntityLocationOptionEntityCrossRef::class,
+        MealJournalEntitySocialOptionEntityCrossRef::class
     ],
     version = 1,
     exportSchema = true
@@ -88,6 +103,7 @@ abstract class LelloDatabase : RoomDatabase() {
 
     // journals
     abstract fun moodJournalEntryDao(): MoodJournalDao
+    abstract fun mealJournalDao(): MealJournalDao
     abstract fun sleepJournalDao(): SleepJournalDao
     abstract fun journalCategoryDao(): JournalCategoryDao
 

--- a/core/database/src/main/java/io/github/faening/lello/core/database/dao/MealJournalDao.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/dao/MealJournalDao.kt
@@ -1,0 +1,69 @@
+package io.github.faening.lello.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntity
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityAppetiteOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityFoodOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityLocationOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityMealOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityPortionOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntitySocialOptionEntityCrossRef
+import io.github.faening.lello.core.database.model.journal.meal.MealJournalEntityWithOptions
+import io.github.faening.lello.core.domain.repository.JournalResources
+
+@Dao
+interface MealJournalDao : JournalResources<MealJournalEntity> {
+
+    @Transaction
+    @Query("SELECT * FROM meal_journals ORDER BY mealTime DESC")
+    override suspend fun getAll(): List<MealJournalEntity>
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM meal_journals
+            WHERE mealJournalId = :id
+            LIMIT 1
+        """
+    )
+    override suspend fun getById(id: Long): MealJournalEntity?
+
+    @Transaction
+    @Query(
+        value = """
+            SELECT * FROM meal_journals
+            WHERE mealJournalId = :id
+            LIMIT 1
+        """
+    )
+    suspend fun getByIdWithOptions(id: Long): MealJournalEntityWithOptions?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    override suspend fun insert(entry: MealJournalEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMealRefs(refs: List<MealJournalEntityMealOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAppetiteRefs(refs: List<MealJournalEntityAppetiteOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFoodRefs(refs: List<MealJournalEntityFoodOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPortionRefs(refs: List<MealJournalEntityPortionOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLocationRefs(refs: List<MealJournalEntityLocationOptionEntityCrossRef>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSocialRefs(refs: List<MealJournalEntitySocialOptionEntityCrossRef>)
+
+    @Delete
+    override suspend fun delete(id: MealJournalEntity)
+}

--- a/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/di/DaoModule.kt
@@ -18,6 +18,11 @@ internal object DaoModule {
     ) = database.moodJournalEntryDao()
 
     @Provides
+    fun provideMealJournalDao(
+        database: LelloDatabase,
+    ) = database.mealJournalDao()
+
+    @Provides
     fun provideSleepJournalDao(
         database: LelloDatabase,
     ) = database.sleepJournalDao()

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityAppetiteOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityAppetiteOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_appetite_options_cross_ref",
+    primaryKeys = ["mealJournalId", "appetiteOptionId"],
+    indices = [Index(value = ["appetiteOptionId"])]
+)
+data class MealJournalEntityAppetiteOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val appetiteOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityFoodOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityFoodOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_food_options_cross_ref",
+    primaryKeys = ["mealJournalId", "foodOptionId"],
+    indices = [Index(value = ["foodOptionId"])]
+)
+data class MealJournalEntityFoodOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val foodOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityLocationOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityLocationOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_location_options_cross_ref",
+    primaryKeys = ["mealJournalId", "locationOptionId"],
+    indices = [Index(value = ["locationOptionId"])]
+)
+data class MealJournalEntityLocationOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val locationOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityMealOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityMealOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_meal_options_cross_ref",
+    primaryKeys = ["mealJournalId", "mealOptionId"],
+    indices = [Index(value = ["mealOptionId"])]
+)
+data class MealJournalEntityMealOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val mealOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityPortionOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityPortionOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_portion_options_cross_ref",
+    primaryKeys = ["mealJournalId", "portionOptionId"],
+    indices = [Index(value = ["portionOptionId"])]
+)
+data class MealJournalEntityPortionOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val portionOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntitySocialOptionEntityCrossRef.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntitySocialOptionEntityCrossRef.kt
@@ -1,0 +1,14 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "meal_journals_social_options_cross_ref",
+    primaryKeys = ["mealJournalId", "socialOptionId"],
+    indices = [Index(value = ["socialOptionId"])]
+)
+data class MealJournalEntitySocialOptionEntityCrossRef(
+    val mealJournalId: Long,
+    val socialOptionId: Long,
+)

--- a/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityWithOptions.kt
+++ b/core/database/src/main/java/io/github/faening/lello/core/database/model/journal/meal/MealJournalEntityWithOptions.kt
@@ -1,0 +1,88 @@
+package io.github.faening.lello.core.database.model.journal.meal
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+import io.github.faening.lello.core.database.model.option.AppetiteOptionEntity
+import io.github.faening.lello.core.database.model.option.FoodOptionEntity
+import io.github.faening.lello.core.database.model.option.LocationOptionEntity
+import io.github.faening.lello.core.database.model.option.MealOptionEntity
+import io.github.faening.lello.core.database.model.option.PortionOptionEntity
+import io.github.faening.lello.core.database.model.option.SocialOptionEntity
+import io.github.faening.lello.core.database.model.option.toModel
+import io.github.faening.lello.core.model.journal.MealJournal
+
+data class MealJournalEntityWithOptions(
+    @Embedded val entry: MealJournalEntity,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "mealOptionId",
+        associateBy = Junction(
+            value = MealJournalEntityMealOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "mealOptionId"
+        )
+    )
+    val mealOptions: List<MealOptionEntity>,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "appetiteOptionId",
+        associateBy = Junction(
+            value = MealJournalEntityAppetiteOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "appetiteOptionId"
+        )
+    )
+    val appetiteOptions: List<AppetiteOptionEntity>,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "foodOptionId",
+        associateBy = Junction(
+            value = MealJournalEntityFoodOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "foodOptionId"
+        )
+    )
+    val foodOptions: List<FoodOptionEntity>,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "portionOptionId",
+        associateBy = Junction(
+            value = MealJournalEntityPortionOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "portionOptionId"
+        )
+    )
+    val portionOptions: List<PortionOptionEntity>,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "locationOptionId",
+        associateBy = Junction(
+            value = MealJournalEntityLocationOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "locationOptionId"
+        )
+    )
+    val locationOptions: List<LocationOptionEntity>,
+    @Relation(
+        parentColumn = "mealJournalId",
+        entityColumn = "socialOptionId",
+        associateBy = Junction(
+            value = MealJournalEntitySocialOptionEntityCrossRef::class,
+            parentColumn = "mealJournalId",
+            entityColumn = "socialOptionId"
+        )
+    )
+    val socialOptions: List<SocialOptionEntity>,
+)
+
+fun MealJournalEntityWithOptions.toModel() = MealJournal(
+    id = entry.mealJournalId,
+    mealTime = entry.mealTime,
+    mealOptions = mealOptions.map { it.toModel() },
+    appetiteOptions = appetiteOptions.map { it.toModel() },
+    foodOptions = foodOptions.map { it.toModel() },
+    portionOptions = portionOptions.map { it.toModel() },
+    locationOptions = locationOptions.map { it.toModel() },
+    socialOptions = socialOptions.map { it.toModel() },
+)

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/journal/MealJournalUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/journal/MealJournalUseCase.kt
@@ -1,0 +1,25 @@
+package io.github.faening.lello.core.domain.usecase.journal
+
+import io.github.faening.lello.core.domain.repository.JournalResources
+import io.github.faening.lello.core.model.journal.MealJournal
+import javax.inject.Inject
+
+class MealJournalUseCase @Inject constructor(
+    private val repository: JournalResources<MealJournal>,
+) {
+    suspend fun getAll(): List<MealJournal> {
+        return repository.getAll()
+    }
+
+    suspend fun getById(id: Long): MealJournal? {
+        return repository.getById(id)
+    }
+
+    suspend fun save(vararg entries: MealJournal) {
+        entries.forEach { repository.insert(it) }
+    }
+
+    suspend fun delete(vararg entries: MealJournal) {
+        entries.forEach { repository.delete(it) }
+    }
+}

--- a/feature/journal/meal/src/main/java/io/github/faening/lello/feature/journal/meal/MealJournalViewModel.kt
+++ b/feature/journal/meal/src/main/java/io/github/faening/lello/feature/journal/meal/MealJournalViewModel.kt
@@ -9,6 +9,7 @@ import io.github.faening.lello.core.domain.usecase.options.LocationOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.MealOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.PortionOptionUseCase
 import io.github.faening.lello.core.domain.usecase.options.SocialOptionUseCase
+import io.github.faening.lello.core.domain.usecase.journal.MealJournalUseCase
 import io.github.faening.lello.core.model.option.AppetiteOption
 import io.github.faening.lello.core.model.option.FoodOption
 import io.github.faening.lello.core.model.option.LocationOption
@@ -26,6 +27,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MealJournalViewModel @Inject constructor(
+    private val mealJournalUseCase: MealJournalUseCase,
     mealOptionUseCase: MealOptionUseCase,
     appetiteOptionUseCase: AppetiteOptionUseCase,
     foodOptionUseCase: FoodOptionUseCase,
@@ -159,7 +161,7 @@ class MealJournalViewModel @Inject constructor(
         if (_mealJournal.value != null) return
         viewModelScope.launch {
             val journal = buildMealournal()
-            // mealJournalUseCase.save(journal)
+            mealJournalUseCase.save(journal)
         }
     }
 }


### PR DESCRIPTION
## Summary
- create database crossrefs and MealJournal entity wrapper
- implement MealJournalDao and hook it into DaoModule
- store MealJournal via repository and use case
- wire MealJournal persistence in ViewModel
- update repository bindings and database entities

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d02671420832c9fb9586859247cb1