### PR TITLE
LEL-023 feat(feature/home): Implement daily check-in progress

### DIFF
--- a/core/designsystem/src/main/java/io/github/faening/lello/core/designsystem/component/card/CheckInDailyCard.kt
+++ b/core/designsystem/src/main/java/io/github/faening/lello/core/designsystem/component/card/CheckInDailyCard.kt
@@ -38,6 +38,7 @@ import io.github.faening.lello.core.designsystem.theme.Yellow500
 @Composable
 fun CheckInDailyCard(
     currentStep: Int, // 1..4
+    subtitle: String,
     modifier: Modifier = Modifier
 ) {
     val progressTotal = 4
@@ -89,7 +90,7 @@ fun CheckInDailyCard(
                     Spacer(modifier = Modifier.height(Dimension.Small))
 
                     Text(
-                        text = "Preencha todos os diários ao menos uma vez para ganhar 10 moedas extra",
+                        text = subtitle,
                         style = MaterialTheme.typography.bodyMedium,
                         color = Grey500
                     )
@@ -128,7 +129,8 @@ fun CheckInDailyCard(
 private fun CheckInDailyCardPreview() {
     LelloTheme {
         CheckInDailyCard(
-            currentStep = 2
+            currentStep = 2,
+            subtitle = "Preencha todos os diários ao menos uma vez para ganhar 10 moedas extra"
         )
     }
 }

--- a/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/reward/DailyCheckInUseCase.kt
+++ b/core/domain/src/main/java/io/github/faening/lello/core/domain/usecase/reward/DailyCheckInUseCase.kt
@@ -1,0 +1,79 @@
+package io.github.faening.lello.core.domain.usecase.reward
+
+import io.github.faening.lello.core.domain.usecase.journal.MealJournalUseCase
+import io.github.faening.lello.core.domain.usecase.journal.MoodJournalUseCase
+import io.github.faening.lello.core.domain.usecase.journal.SleepJournalUseCase
+import io.github.faening.lello.core.domain.util.isSameDay
+import io.github.faening.lello.core.model.journal.MealJournal
+import io.github.faening.lello.core.model.journal.MoodJournal
+import io.github.faening.lello.core.model.journal.SleepJournal
+import io.github.faening.lello.core.model.reward.DailyCheckInState
+import io.github.faening.lello.core.model.reward.RewardBalance
+import io.github.faening.lello.core.model.reward.RewardHistory
+import io.github.faening.lello.core.model.reward.RewardOrigin
+import io.github.faening.lello.core.model.reward.RewardPoints
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.mapLatest
+import java.time.LocalDate
+import javax.inject.Inject
+
+class DailyCheckInUseCase @Inject constructor(
+    private val moodJournalUseCase: MoodJournalUseCase,
+    private val mealJournalUseCase: MealJournalUseCase,
+    private val sleepJournalUseCase: SleepJournalUseCase,
+    private val rewardBalanceUseCase: RewardBalanceUseCase,
+    private val rewardHistoryUseCase: RewardHistoryUseCase
+) {
+
+    fun observeDailyCheckIn(): Flow<DailyCheckInState> {
+        return combine(
+            moodJournalUseCase.getAll(),
+            mealJournalUseCase.getAll(),
+            sleepJournalUseCase.getAll(),
+            rewardBalanceUseCase.observeBalance()
+        ) { mood, meal, sleep, balance ->
+            DailyCheckInData(mood, meal, sleep, balance)
+        }.mapLatest { data ->
+            calculateState(data)
+        }
+    }
+
+    private suspend fun calculateState(data: DailyCheckInData): DailyCheckInState {
+        val today = LocalDate.now()
+        var steps = 0
+
+        if (data.moodJournals.any { it.createdAt.isSameDay(today) }) steps++
+        if (data.sleepJournals.any { it.createdAt.isSameDay(today) }) steps++
+        if (data.mealJournals.any { it.createdAt.isSameDay(today) }) steps++
+        // Medication journal not implemented yet
+
+        val bonusAlreadyGiven =
+            data.rewardBalance.lastDailyAchievementReward?.isSameDay(today) == true
+
+        if (steps >= 4 && !bonusAlreadyGiven) {
+            val now = System.currentTimeMillis()
+            val updatedBalance = data.rewardBalance.copy(
+                totalCoins = data.rewardBalance.totalCoins + RewardPoints.DAILY_ACHIEVEMENTS.basePoints,
+                lastDailyAchievementReward = now
+            )
+            rewardBalanceUseCase.insertOrUpdate(updatedBalance)
+            val history = RewardHistory(
+                rewardOrigin = RewardOrigin.DAILY_ACHIEVEMENT,
+                rewardAmount = RewardPoints.DAILY_ACHIEVEMENTS.basePoints,
+                createdAt = now
+            )
+            rewardHistoryUseCase.insert(history)
+            return DailyCheckInState(currentStep = steps, bonusReceived = true)
+        }
+
+        return DailyCheckInState(currentStep = steps, bonusReceived = bonusAlreadyGiven)
+    }
+
+    private data class DailyCheckInData(
+        val moodJournals: List<MoodJournal>,
+        val mealJournals: List<MealJournal>,
+        val sleepJournals: List<SleepJournal>,
+        val rewardBalance: RewardBalance
+    )
+}

--- a/core/model/src/main/java/io/github/faening/lello/core/model/reward/DailyCheckInState.kt
+++ b/core/model/src/main/java/io/github/faening/lello/core/model/reward/DailyCheckInState.kt
@@ -1,0 +1,11 @@
+package io.github.faening.lello.core.model.reward
+
+/**
+ * Represents the current progress of the daily check-in.
+ * @param currentStep Number of different journals filled today (0..4).
+ * @param bonusReceived True when the daily achievement reward has been granted for today.
+ */
+data class DailyCheckInState(
+    val currentStep: Int = 0,
+    val bonusReceived: Boolean = false
+)

--- a/feature/home/src/main/java/io/github/faening/lello/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/io/github/faening/lello/feature/home/screen/HomeScreen.kt
@@ -24,6 +24,7 @@ import io.github.faening.lello.core.designsystem.component.card.CheckInDailyCard
 import io.github.faening.lello.core.designsystem.theme.LelloTheme
 import io.github.faening.lello.core.model.journal.JournalBonusState
 import io.github.faening.lello.core.model.journal.JournalCategory
+import io.github.faening.lello.core.model.reward.DailyCheckInState
 import io.github.faening.lello.feature.home.HomeViewModel
 import io.github.faening.lello.feature.journal.meal.JournalMealDestinations
 import io.github.faening.lello.feature.journal.medication.navigation.JournalMedicationDestinations
@@ -38,11 +39,13 @@ fun HomeScreen(
 ) {
     val journalCategories by viewModel.journalCategories.collectAsState()
     val bonusState by viewModel.journalBonusState.collectAsState()
+    val checkInState by viewModel.dailyCheckInState.collectAsState()
 
     LelloTheme {
         HomeScreenContainer(
             journalCategories = journalCategories,
             bonusState = bonusState,
+            checkInState = checkInState,
             onNavigateToModule = onNavigateToModule
         )
     }
@@ -52,6 +55,7 @@ fun HomeScreen(
 private fun HomeScreenContainer(
     journalCategories: List<JournalCategory>,
     bonusState: JournalBonusState,
+    checkInState: DailyCheckInState,
     onNavigateToModule: (String) -> Unit
 ) {
     Scaffold(
@@ -67,6 +71,7 @@ private fun HomeScreenContainer(
             JournalContent(
                 journalCategories = journalCategories,
                 bonusState = bonusState,
+                checkInState = checkInState,
                 onNavigateToModule = onNavigateToModule
             )
         }
@@ -84,6 +89,7 @@ private fun HomeScreenTopAppBar() {
 private fun JournalContent(
     journalCategories: List<JournalCategory> = emptyList(),
     bonusState: JournalBonusState,
+    checkInState: DailyCheckInState,
     onNavigateToModule: (String) -> Unit
 ) {
     Column(
@@ -93,7 +99,12 @@ private fun JournalContent(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CheckInDailyCard(
-            currentStep = 2
+            currentStep = checkInState.currentStep,
+            subtitle = if (checkInState.bonusReceived) {
+                "Parabéns! Você adquiriu moedas extra hoje."
+            } else {
+                "Preencha todos os diários ao menos uma vez para ganhar 10 moedas extra"
+            }
         )
         Spacer(modifier = Modifier.height(32.dp))
 


### PR DESCRIPTION
## Summary
- allow CheckInDailyCard to display dynamic subtitle
- add DailyCheckInState model to represent progress
- create DailyCheckInUseCase for calculating daily progress and giving rewards
- wire DailyCheckInUseCase into HomeViewModel and HomeScreen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c93d99084832cac270cfd4c047433